### PR TITLE
fix: resolve generate image flow errors

### DIFF
--- a/docs/devlog-2026-02-22-fix-generate.md
+++ b/docs/devlog-2026-02-22-fix-generate.md
@@ -1,0 +1,72 @@
+# Artio DEVLOG
+
+## 2026-02-22 — Fix Generate Image Flow
+
+### Context
+
+User `minhthang421992@gmail.com` (premium) reported "Something went wrong" khi bấm Generate sau khi upload ảnh trong template flow.
+
+---
+
+### Bug #1: Missing `model_id` Column in `generation_jobs`
+
+**Symptom:** "Something went wrong" ngay sau khi bấm Generate.
+
+**Root Cause:**
+- `generation_repository.dart` insert `model_id` field vào bảng `generation_jobs`
+- Bảng DB không có column `model_id` (chưa có trong migration)
+- → `PostgrestException("column generation_jobs.model_id does not exist")` → `AppException.unknown()` → "Something went wrong"
+
+**Verified via:**
+- Supabase REST API query: `?select=model_id` → trả về `"column generation_jobs.model_id does not exist"` (HTTP 400, error code `42703`)
+- Không có `model_id` trong `generation_jobs` schema (`migrations/20260128115551_add_deleted_at_and_storage_bucket.sql`)
+
+**Fix:**
+```sql
+-- supabase/migrations/20260222_add_model_id_to_generation_jobs.sql
+ALTER TABLE generation_jobs
+  ADD COLUMN IF NOT EXISTS model_id TEXT;
+```
+
+Applied trực tiếp lên Supabase remote database qua SQL Editor.
+
+---
+
+### Bug #2: `Image.network()` nhận storage path thay vì HTTPS URL
+
+**Symptom:** Sau khi generate thành công (green checkmark), app hiển thị lỗi đỏ:
+```
+Invalid argument(s): No host specified in URI file:///07410caf.../uuid.jpg
+```
+
+**Root Cause:**
+- `CompletedStatusSection` widget (`generation_progress_sections.dart`) gọi `Image.network(resultUrls!.first)` trực tiếp
+- `resultUrls` chứa **Supabase storage paths** như `userId/filename.jpg`, không phải HTTPS URL
+- Flutter `Image.network()` cố parse storage path → không có scheme → Dart tự thêm `file://` prefix → `Uri.host` trống → throw `Invalid argument(s): No host specified`
+
+**Fix:**
+1. Tạo `lib/core/services/storage_url_service.dart`:
+   - `StorageUrlService.signedUrl(path)` → tạo signed HTTPS URL từ Supabase storage path
+   - `signedStorageUrlProvider` (Riverpod `FutureProvider.family`) để dùng trong widget
+2. Thay `Image.network(resultUrls!.first)` bằng `_SignedStorageImage(storagePath)`:
+   - `_SignedStorageImage` là `ConsumerWidget`
+   - Watch `signedStorageUrlProvider(storagePath)` → khi signed URL ready, render `Image.network(url)`
+
+---
+
+### Files Changed
+
+| File | Type | Change |
+|------|------|--------|
+| `supabase/migrations/20260222_add_model_id_to_generation_jobs.sql` | NEW | Add `model_id TEXT` column to `generation_jobs` |
+| `lib/core/services/storage_url_service.dart` | NEW | `StorageUrlService` + `signedStorageUrlProvider` |
+| `lib/features/template_engine/presentation/widgets/generation_progress_sections.dart` | MODIFY | Replace `Image.network(storagePath)` with `_SignedStorageImage` widget |
+
+---
+
+### Verification
+
+- ✅ Build: `flutter build apk --debug` → success
+- ✅ Install: `adb install -r app-debug.apk` → success  
+- ✅ Test: User `minhthang421992@gmail.com` confirmed generate hoạt động sau fix
+- ✅ `dart analyze` → No issues found

--- a/lib/core/services/storage_url_service.dart
+++ b/lib/core/services/storage_url_service.dart
@@ -1,0 +1,38 @@
+import 'package:artio/core/providers/supabase_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+const _bucket = 'generated-images';
+const _signedUrlExpiry = 3600; // 1 hour
+
+/// Converts a Supabase storage path to a signed HTTPS URL.
+class StorageUrlService {
+  const StorageUrlService(this._supabase);
+  final SupabaseClient _supabase;
+
+  /// Returns a signed URL for a storage path like `userId/filename.jpg`.
+  /// If the input is already a full HTTPS URL, returns it unchanged.
+  Future<String?> signedUrl(String path) async {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+    final response = await _supabase.storage
+        .from(_bucket)
+        .createSignedUrl(path, _signedUrlExpiry);
+    return response;
+  }
+}
+
+final storageUrlServiceProvider = Provider<StorageUrlService>((ref) {
+  return StorageUrlService(ref.watch(supabaseClientProvider));
+});
+
+/// Resolves a single storage path to a signed HTTPS URL.
+/// Used in widgets via `ref.watch(signedStorageUrlProvider(path))`.
+final signedStorageUrlProvider = FutureProvider.family<String?, String>((
+  ref,
+  storagePath,
+) async {
+  final service = ref.watch(storageUrlServiceProvider);
+  return service.signedUrl(storagePath);
+});

--- a/lib/features/template_engine/presentation/widgets/generation_progress_sections.dart
+++ b/lib/features/template_engine/presentation/widgets/generation_progress_sections.dart
@@ -3,10 +3,12 @@ import 'package:artio/core/design_system/app_dimensions.dart';
 import 'package:artio/core/design_system/app_gradients.dart';
 import 'package:artio/core/design_system/app_spacing.dart';
 import 'package:artio/core/design_system/app_typography.dart';
+import 'package:artio/core/services/storage_url_service.dart';
 import 'package:artio/features/template_engine/domain/entities/generation_job_model.dart';
 import 'package:artio/shared/widgets/loading_state_widget.dart';
 import 'package:artio/theme/app_colors.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Pulsing progress bar + glow ring for generating/processing states.
 class ProgressStatusSection extends StatelessWidget {
@@ -159,18 +161,42 @@ class CompletedStatusSection extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.md),
         if (resultUrls != null && resultUrls!.isNotEmpty)
-          ClipRRect(
-            borderRadius: AppDimensions.cardRadius,
-            child: Image.network(
-              resultUrls!.first,
-              fit: BoxFit.cover,
-              loadingBuilder: (context, child, loadingProgress) {
-                if (loadingProgress == null) return child;
-                return const LoadingStateWidget();
-              },
-            ),
-          ),
+          _SignedStorageImage(storagePath: resultUrls!.first),
       ],
+    );
+  }
+}
+
+/// Resolves a Supabase storage path to a signed URL before displaying.
+/// Prevents `Invalid argument: No host specified` errors from raw storage paths.
+class _SignedStorageImage extends ConsumerWidget {
+  const _SignedStorageImage({required this.storagePath});
+
+  final String storagePath;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final urlAsync = ref.watch(signedStorageUrlProvider(storagePath));
+
+    return urlAsync.when(
+      loading: () => const LoadingStateWidget(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (url) {
+        if (url == null) return const SizedBox.shrink();
+        return ClipRRect(
+          borderRadius: AppDimensions.cardRadius,
+          child: Image.network(
+            url,
+            fit: BoxFit.cover,
+            loadingBuilder: (context, child, loadingProgress) {
+              if (loadingProgress == null) return child;
+              return const LoadingStateWidget();
+            },
+            errorBuilder: (context, error, stackTrace) =>
+                const SizedBox.shrink(),
+          ),
+        );
+      },
     );
   }
 }

--- a/supabase/migrations/20260222_add_model_id_to_generation_jobs.sql
+++ b/supabase/migrations/20260222_add_model_id_to_generation_jobs.sql
@@ -1,0 +1,6 @@
+-- Migration: Add model_id column to generation_jobs
+-- Bug fix: Dart client inserts model_id but column was missing → "Something went wrong"
+-- Created: 2026-02-22
+
+ALTER TABLE generation_jobs
+  ADD COLUMN IF NOT EXISTS model_id TEXT;


### PR DESCRIPTION
Superseded by #29 — same fixes rebased on master without regressions.\n\nOriginal PR had branch divergence that reverted tech debt fixes (MIME detection, SupabaseClient type, input_image_paths cleanup).