### PR TITLE
chore: untrack .gemini/ directory

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,6 +1,0 @@
-# Gemini Configuration
-
-> Project-specific instructions are in the root [GEMINI.md](../GEMINI.md).
-> Global behavioral rules are in `~/.gemini/GEMINI.md`.
-
-This file exists for IDE discovery. All rules are consolidated in the root `GEMINI.md`.


### PR DESCRIPTION
Untrack `.gemini/` directory — local AI tooling config, not project source.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Untrack the .gemini/ directory so local tooling config isn’t stored in the repo. Removes .gemini/GEMINI.md; no app code changes.

<sup>Written for commit db9011531133104b8aae64801d45f4e022b14eaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

