### PR TITLE
fix(gallery): add Retry button to all image load error states (m2)

### DIFF
--- a/lib/features/gallery/presentation/widgets/image_viewer_image_page.dart
+++ b/lib/features/gallery/presentation/widgets/image_viewer_image_page.dart
@@ -90,6 +90,20 @@ class ImageViewerImagePage extends ConsumerWidget {
                             fontSize: 14,
                           ),
                         ),
+                        const SizedBox(height: AppSpacing.sm),
+                        GestureDetector(
+                          onTap: () => ref.invalidate(
+                            signedStorageUrlProvider(rawPath!),
+                          ),
+                          child: const Text(
+                            'Retry',
+                            style: TextStyle(
+                              color: AppColors.primaryCta,
+                              fontSize: 14,
+                              decoration: TextDecoration.underline,
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                     data: (signedUrl) => signedUrl == null
@@ -152,6 +166,20 @@ class ImageViewerImagePage extends ConsumerWidget {
                                       style: TextStyle(
                                         color: AppColors.textMuted,
                                         fontSize: 14,
+                                      ),
+                                    ),
+                                    const SizedBox(height: AppSpacing.sm),
+                                    GestureDetector(
+                                      onTap: () => ref.invalidate(
+                                        signedStorageUrlProvider(rawPath!),
+                                      ),
+                                      child: const Text(
+                                        'Retry',
+                                        style: TextStyle(
+                                          color: AppColors.primaryCta,
+                                          fontSize: 14,
+                                          decoration: TextDecoration.underline,
+                                        ),
                                       ),
                                     ),
                                   ],

--- a/lib/features/gallery/presentation/widgets/interactive_gallery_item.dart
+++ b/lib/features/gallery/presentation/widgets/interactive_gallery_item.dart
@@ -180,6 +180,21 @@ class _InteractiveGalleryItemState extends ConsumerState<InteractiveGalleryItem>
                           : AppColors.textMutedLight,
                     ),
                   ),
+                  const SizedBox(height: AppSpacing.xs),
+                  GestureDetector(
+                    onTap: () => ref.invalidate(
+                      signedStorageUrlProvider(item.imageUrl!),
+                    ),
+                    child: Text(
+                      'Retry',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: isDark
+                            ? AppColors.primaryCta
+                            : AppColors.primaryCta,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -257,6 +272,28 @@ class _InteractiveGalleryItemState extends ConsumerState<InteractiveGalleryItem>
                                         ? AppColors.textMuted
                                         : AppColors.textMutedLight,
                                   ),
+                            ),
+                            const SizedBox(height: AppSpacing.xs),
+                            GestureDetector(
+                              onTap: () {
+                                // Evict from image cache so CachedNetworkImage
+                                // re-fetches on next render.
+                                CachedNetworkImage.evictFromCache(
+                                  item.imageUrl!,
+                                );
+                                // Invalidate provider to get a fresh signed URL.
+                                ref.invalidate(
+                                  signedStorageUrlProvider(item.imageUrl!),
+                                );
+                              },
+                              child: Text(
+                                'Retry',
+                                style: Theme.of(context).textTheme.labelSmall
+                                    ?.copyWith(
+                                      color: AppColors.primaryCta,
+                                      decoration: TextDecoration.underline,
+                                    ),
+                              ),
                             ),
                           ],
                         ),


### PR DESCRIPTION
## Problem

Issue m2 from PR review was marked **Partial** — error states in gallery showed broken image icon + text but no way for user to retry. Signed URLs can expire or fail transiently, leaving users stuck.

## Fix

Added a **Retry** tap target to **4 error states** across 2 widgets:

### `InteractiveGalleryItem` (gallery grid thumbnail)
1. **signedStorageUrlProvider error** → `ref.invalidate(signedStorageUrlProvider(path))` re-resolves URL
2. **CachedNetworkImage errorWidget** → evicts image from cache + invalidates provider to force fresh URL + re-render

### `ImageViewerImagePage` (full-screen viewer)
3. **signedStorageUrlProvider error** → invalidates provider
4. **Image.network errorBuilder** → invalidates provider to get fresh signed URL

## Technical approach

```dart
GestureDetector(
  onTap: () => ref.invalidate(signedStorageUrlProvider(rawPath)),
  child: Text('Retry', ...),
)
```

Riverpod invalidation triggers a new `signedUrl()` call from Supabase, then the widget rebuilds with a fresh URL.

## Verification
- `flutter analyze`: 0 issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Retry button to all gallery image error states so users can reload images when signed URLs fail or expire. Prevents getting stuck on broken thumbnails or viewer images; addresses review item m2.

- **Bug Fixes**
  - InteractiveGalleryItem: Retry on provider error invalidates signedStorageUrlProvider(path).
  - InteractiveGalleryItem: Retry on image load error evicts CachedNetworkImage and invalidates the provider.
  - ImageViewerImagePage: Retry on provider or image error invalidates the provider to fetch a fresh signed URL.

<sup>Written for commit 38d2a0fe3b5e62ad377d4cf7598b55a643f3b48a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

