### PR TITLE
chore(android): downgrade Gradle wrapper 8.14 → 8.13

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip


### PR DESCRIPTION
Gradle 8.14 has a known composite build bug with Flutter's `includeBuild` in `settings.gradle.kts` — causes `ImmutableWorkspaceMetadata FileNotFoundException` on `metadata.bin`. AGP minimum is 8.13. Using 8.13 exactly: meets requirement, avoids the bug. Build verified OK locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded the Android Gradle wrapper from 8.14 to 8.13 to avoid a composite build bug with Flutter’s includeBuild that throws ImmutableWorkspaceMetadata FileNotFoundException. 8.13 meets the AGP minimum and restores successful builds.

<sup>Written for commit 0bc75f8aca367ae7eef99d2b10e893b9357af8d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

