### PR TITLE
fix: resolve 7 RevenueCat blocking bugs from red-team review

### DIFF
--- a/docs/revenuecat-checklist.md
+++ b/docs/revenuecat-checklist.md
@@ -1,36 +1,36 @@
 # RevenueCat Dashboard Setup Checklist
 
-Checklist để verify RevenueCat Dashboard đã config đúng cho Artio app.
+Checklist de verify RevenueCat Dashboard da config dung cho Artio app.
 
 ## 1. Project Setup
 
-- [ ] Project đã tạo trên https://app.revenuecat.com
-- [ ] **Test Store app** đã thêm (Apps → + New → "Test Store")
-- [ ] API key prefix `test_` (current: `test_OMDqQPXskGuySoMsazAoFwKuaZo`)
+- [x] Project da tao tren https://app.revenuecat.com (`proj7a945f6d`)
+- [x] **Test Store app** da them (Apps > + New > "Test Store") (`appa68f39b27b`)
+- [x] API key prefix `test_` (current: `test_OMDqQPXskGuySoMsazAoFwKuaZo`)
 
 ## 2. Products
 
-- [ ] Product cho **Pro** (e.g. `pro_monthly`, `pro_yearly`)
-- [ ] Product cho **Ultra** (e.g. `ultra_monthly`, `ultra_yearly`)
-- [ ] Mỗi product có price được set
+- [x] Product cho **Pro** (`artio_pro_monthly`, `artio_pro_yearly`)
+- [x] Product cho **Ultra** (`artio_ultra_monthly`, `artio_ultra_yearly`)
+- [ ] Moi product co price duoc set
 
 ## 3. Entitlements
 
-- [ ] Entitlement **`pro`** — match string `pro` trong code
-- [ ] Entitlement **`ultra`** — match string `ultra` trong code
-- [ ] Products Pro gắn vào entitlement `pro`
-- [ ] Products Ultra gắn vào entitlement `ultra`
+- [x] Entitlement **`pro`** — match string `pro` trong code (`entl2665d1fa2e`)
+- [x] Entitlement **`ultra`** — match string `ultra` trong code (`entl0aba27660b`)
+- [x] Products Pro gan vao entitlement `pro`
+- [x] Products Ultra gan vao entitlement `ultra`
 
 ## 4. Offerings
 
-- [ ] Offering **`default`** đã tạo
-- [ ] Đánh dấu là **Current** (code dùng `offerings.current`)
-- [ ] Ít nhất 1 Package (e.g. `$rc_monthly`, `$rc_annual`)
-- [ ] Mỗi package gắn đúng product
+- [x] Offering **`default`** da tao (`ofrngab4dda9897`)
+- [x] Danh dau la **Current** (code dung `offerings.current`)
+- [x] 4 Packages (`$rc_monthly`, `$rc_annual`, `artio_ultra_monthly`, `artio_ultra_annual`)
+- [x] Moi package gan dung product
 
 ## 5. Verify
 
-- [ ] Offerings → `default` → thấy packages + products
-- [ ] Entitlements → `pro`/`ultra` → có products gắn
-- [ ] API Keys → key thuộc Test Store app
-- [ ] Chạy app debug → console in `"Offerings fetched"`
+- [x] Offerings > `default` > thay packages + products
+- [x] Entitlements > `pro`/`ultra` > co products gan
+- [ ] API Keys > key thuoc Test Store app
+- [ ] Chay app debug > console in `"Offerings fetched"`

--- a/lib/features/auth/presentation/view_models/auth_view_model.dart
+++ b/lib/features/auth/presentation/view_models/auth_view_model.dart
@@ -92,12 +92,17 @@ class AuthViewModel extends _$AuthViewModel implements Listenable {
   Future<void> _handleSignedIn() async {
     try {
       final authRepo = ref.read(authRepositoryProvider);
-      final user = await authRepo.getCurrentUserWithProfile();
-      if (user != null) {
-        state = AuthState.authenticated(user);
-      } else {
+      final supabaseUser = authRepo.currentUser;
+      if (supabaseUser == null) {
         state = const AuthState.unauthenticated();
+        return;
       }
+      // fetchOrCreateProfile handles RC login + profile creation.
+      // Use returned profile directly — no need for getCurrentUserWithProfile().
+      final profile = await authRepo.fetchOrCreateProfile(supabaseUser);
+      state = AuthState.authenticated(
+        UserModel.fromSupabaseUser(supabaseUser, profile: profile),
+      );
     } on Exception catch (e) {
       state = AuthState.error(AppExceptionMapper.toUserMessage(e));
     } finally {

--- a/lib/features/subscription/data/repositories/subscription_repository.dart
+++ b/lib/features/subscription/data/repositories/subscription_repository.dart
@@ -37,7 +37,7 @@ class SubscriptionRepository implements ISubscriptionRepository {
       return packages
           .map(
             (p) => SubscriptionPackage(
-              identifier: p.identifier,
+              identifier: p.storeProduct.identifier,
               priceString: p.storeProduct.priceString,
               nativePackage: p,
             ),

--- a/lib/features/subscription/presentation/screens/paywall_screen.dart
+++ b/lib/features/subscription/presentation/screens/paywall_screen.dart
@@ -328,9 +328,11 @@ class _PaywallScreenState extends ConsumerState<PaywallScreen> {
                         fontWeight: FontWeight.w800,
                       ),
                     ),
-                    const Text(
-                      'per month',
-                      style: TextStyle(
+                    Text(
+                      pkg.identifier.contains('yearly')
+                          ? 'per year'
+                          : 'per month',
+                      style: const TextStyle(
                         color: AppColors.textMuted,
                         fontSize: 11,
                       ),

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -83,13 +83,22 @@ Deno.serve(async (req) => {
             .maybeSingle();
 
         if (!profile) {
-            console.error(
-                `[revenuecat-webhook] CRITICAL: app_user_id ${appUserId} not linked to any profile. Skipping.`
+            console.error(JSON.stringify({
+                level: "error",
+                source: "revenuecat-webhook",
+                event_type: eventType,
+                event_id: eventId,
+                app_user_id: appUserId,
+                product_id: productId,
+                message: "User not linked. Returning 500 for retry.",
+            }));
+            return new Response(
+                JSON.stringify({ error: "User not linked", retryable: true }),
+                {
+                    status: 500,
+                    headers: { "Content-Type": "application/json" },
+                },
             );
-            return new Response(JSON.stringify({ ok: true, skipped: true }), {
-                status: 200,
-                headers: { "Content-Type": "application/json" },
-            });
         }
 
         const userId = profile.id;
@@ -216,9 +225,10 @@ Deno.serve(async (req) => {
             }
 
             case "PRODUCT_CHANGE": {
-                const tierInfo = getTierInfo(productId);
+                const newProductId = event.new_product_id ?? productId;
+                const tierInfo = getTierInfo(newProductId);
                 if (!tierInfo) {
-                    console.warn(`[revenuecat-webhook] Unknown product for change: ${productId}`);
+                    console.warn(`[revenuecat-webhook] Unknown product for change: ${newProductId}`);
                     break;
                 }
 

--- a/supabase/migrations/20260304100000_fix_credit_idempotency_and_rc_index.sql
+++ b/supabase/migrations/20260304100000_fix_credit_idempotency_and_rc_index.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- Migration: Fix credit idempotency race condition + add RC user lookup index
+-- Fixes: Plan Phase 1 Fix 3 (CRITICAL) + Fix 6 (MEDIUM)
+-- =============================================================================
+
+-- 1. Remove duplicate reference_ids (keep the oldest row per reference_id)
+DELETE FROM credit_transactions
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+           ROW_NUMBER() OVER (
+             PARTITION BY reference_id
+             ORDER BY created_at ASC, id ASC
+           ) AS rn
+    FROM credit_transactions
+    WHERE reference_id IS NOT NULL
+  ) dupes
+  WHERE dupes.rn > 1
+);
+
+-- 2. UNIQUE partial index on reference_id (replaces existing non-unique index)
+-- This prevents concurrent webhooks from double-granting credits.
+DROP INDEX IF EXISTS idx_credit_transactions_reference_id;
+CREATE UNIQUE INDEX idx_credit_transactions_reference_id
+  ON credit_transactions(reference_id)
+  WHERE reference_id IS NOT NULL;
+
+-- 2. Update grant function for atomic idempotency using ON CONFLICT
+CREATE OR REPLACE FUNCTION grant_subscription_credits(
+  p_user_id UUID,
+  p_amount INTEGER,
+  p_description TEXT,
+  p_reference_id TEXT
+) RETURNS VOID AS $$
+BEGIN
+  -- Atomic idempotency via UNIQUE constraint + ON CONFLICT
+  INSERT INTO credit_transactions (user_id, amount, type, description, reference_id)
+  VALUES (p_user_id, p_amount, 'subscription', p_description, p_reference_id)
+  ON CONFLICT (reference_id) WHERE reference_id IS NOT NULL DO NOTHING;
+
+  -- Only update balance if row was actually inserted
+  IF FOUND THEN
+    UPDATE user_credits
+    SET balance = balance + p_amount
+    WHERE user_id = p_user_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public;
+
+REVOKE ALL ON FUNCTION grant_subscription_credits(UUID, INTEGER, TEXT, TEXT) FROM authenticated;
+
+-- 3. Index for webhook user lookup by revenuecat_app_user_id (Fix 6)
+CREATE INDEX IF NOT EXISTS idx_profiles_revenuecat_app_user_id
+  ON profiles (revenuecat_app_user_id)
+  WHERE revenuecat_app_user_id IS NOT NULL;

--- a/test/features/auth/presentation/view_models/auth_view_model_test.dart
+++ b/test/features/auth/presentation/view_models/auth_view_model_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart'
     as supabase
-    show AuthChangeEvent, AuthState, Session;
+    show AuthChangeEvent, AuthState, Session, User;
 
 import '../../../../core/fixtures/fixtures.dart';
 
@@ -402,10 +402,19 @@ void main() {
           async.elapse(Duration.zero);
 
           // Simulate auth state change (user signs in via OAuth callback)
-          final user = UserFixtures.authenticated();
+          // _handleSignedIn() now uses currentUser + fetchOrCreateProfile()
+          final fakeUser = _FakeUser();
+          when(() => mockAuthRepo.currentUser).thenReturn(fakeUser);
           when(
-            mockAuthRepo.getCurrentUserWithProfile,
-          ).thenAnswer((_) async => user);
+            () => mockAuthRepo.fetchOrCreateProfile(fakeUser),
+          ).thenAnswer(
+            (_) async => {
+              'id': 'test-user-123',
+              'display_name': 'Test User',
+              'credits': 10,
+              'is_premium': false,
+            },
+          );
 
           // Push auth event — this cancels the timer
           authStreamController.add(
@@ -435,3 +444,18 @@ void main() {
 
 /// Fake [supabase.Session] for triggering auth state changes in tests.
 class _FakeSession extends Fake implements supabase.Session {}
+
+/// Fake [supabase.User] for mocking currentUser in _handleSignedIn flow.
+class _FakeUser extends Fake implements supabase.User {
+  @override
+  String get id => 'test-user-123';
+
+  @override
+  String? get email => 'test@example.com';
+
+  @override
+  Map<String, dynamic>? get userMetadata => {'name': 'Test User'};
+
+  @override
+  String get createdAt => '2026-01-01T00:00:00.000Z';
+}


### PR DESCRIPTION
## Summary

Fixes 7 blocking bugs identified by red-team review that would cause silent failures in the RevenueCat purchase flow.

### CRITICAL (3)
- **Fix 1:** SubscriptionPackage.identifier now uses storeProduct.identifier instead of package type ($rc_monthly). Without this, paywall classified ALL packages as Ultra.
- **Fix 2:** OAuth users (Google/Apple) now get RevenueCat identity linked via etchOrCreateProfile() in _handleSignedIn(). Previously, OAuth users were never linked to RC — webhooks couldn't find them, credits never granted.
- **Fix 3:** Credit idempotency race condition fixed with UNIQUE partial index on eference_id + INSERT ON CONFLICT DO NOTHING. Prevents concurrent webhooks from double-granting credits.

### HIGH (2)
- **Fix 4:** PRODUCT_CHANGE webhook now reads 
ew_product_id instead of old product_id.
- **Fix 5:** Unlinked users now return 500 (retryable) instead of silent 200. RC will retry, giving time for user to link.

### MEDIUM (1)
- **Fix 6:** Added partial index on profiles.revenuecat_app_user_id for faster webhook lookups.

### LOW (1)
- **Fix 7:** Paywall price label now shows 'per year' for yearly packages instead of hardcoded 'per month'.

## Files Changed (7)
| File | Change |
|------|--------|
| \subscription_repository.dart\ | \p.identifier\ → \p.storeProduct.identifier\ |
| \uth_view_model.dart\ | \_handleSignedIn()\ uses \etchOrCreateProfile()\ |
| \20260304100000_fix_credit_idempotency_and_rc_index.sql\ | NEW migration |
| \evenuecat-webhook/index.ts\ | \
ew_product_id\ + return 500 for unlinked |
| \paywall_screen.dart\ | Dynamic period label |
| \uth_view_model_test.dart\ | Updated OAuth test mocks |
| \evenuecat-checklist.md\ | Updated checklist status |

## Verification
- \lutter analyze\ → 0 issues
- \lutter test\ → 698/698 passed

## Post-Merge Actions
- [ ] \supabase db push\ — apply migration
- [ ] \supabase functions deploy revenuecat-webhook\ — redeploy webhook

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven RevenueCat issues that caused silent failures and misclassified plans in the purchase flow. Improves identity linking, webhook reliability (with retryable errors), and credit idempotency.

- **Bug Fixes**
  - Use storeProduct.identifier for paywall packages to classify Pro/Ultra correctly.
  - Link OAuth users to RevenueCat via fetchOrCreateProfile() in _handleSignedIn().
  - Enforce credit idempotency with UNIQUE partial index + ON CONFLICT DO NOTHING.
  - PRODUCT_CHANGE webhook reads new_product_id.
  - Return 500 (retryable JSON) for unlinked users so RevenueCat retries.
  - Add index on profiles.revenuecat_app_user_id for faster webhook lookups.
  - Show “per year” for yearly packages in the paywall.

- **Migration**
  - Run: supabase db push.
  - Deploy: supabase functions deploy revenuecat-webhook.

<sup>Written for commit 1907f7e359cccdeecea258ec74811d40ff19568d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

