### PR TITLE
⚡ Bolt: Add `cacheKey` to `TemplateCard` for better network caching

### DIFF
--- a/lib/features/template_engine/presentation/widgets/template_card.dart
+++ b/lib/features/template_engine/presentation/widgets/template_card.dart
@@ -81,6 +81,7 @@ class _TemplateCardState extends State<TemplateCard>
                   // ── Thumbnail Image ─────────────────────────────────
                   CachedNetworkImage(
                     imageUrl: template.thumbnailUrl,
+                    cacheKey: template.thumbnailUrl.split('?').first,
                     memCacheWidth:
                         400, // Optimize memory usage for card thumbnails
                     fit: BoxFit.cover,


### PR DESCRIPTION
💡 **What:** Added `cacheKey: template.thumbnailUrl.split('?').first` to the `CachedNetworkImage` widget within `TemplateCard`.

🎯 **Why:** Supabase storage signed URLs append unique security tokens as query parameters that change over time. By default, `CachedNetworkImage` uses the entire URL as the cache key. When a URL rotates, the framework treats it as a brand-new image, causing a cache miss, an unnecessary network re-download, and redundant disk storage usage.

📊 **Impact:** Drastically improves cache hit rates for template thumbnails. Prevents network latency overhead and unnecessary disk bloat by normalizing the cache key to the static file path, bypassing ephemeral token rotations.

🔬 **Measurement:** Open the app and observe the template thumbnails on the home screen loading instantly after the first fetch, even if a new signed URL was issued by the backend. Observe `flutter test` passing with zero regressions.

---
*PR created automatically by Jules for task [1483737383860607821](https://jules.google.com/task/1483737383860607821) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a stable `cacheKey` to the `CachedNetworkImage` in `TemplateCard` by stripping query params from signed URLs. This improves cache hits and prevents redundant downloads and disk bloat when Supabase rotates tokens.

<sup>Written for commit eb76a4ee2d9408bd44baf726ae23cad1ecd38ced. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

