### PR TITLE
🎨 Palette: Add semantics to empty gallery illustration button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Improve Interactive Element Accessibility in Flutter
 **Learning:** In Flutter, `GestureDetector` widgets do not automatically provide accessibility semantics (unlike built-in buttons like `ElevatedButton` or `TextButton`). Using them for interactive elements without a `Semantics` wrapper causes screen readers to ignore them, making the UI inaccessible for users with visual impairments.
 **Action:** When using `GestureDetector` for interactive elements (such as links or custom cards), always wrap it in a `Semantics` widget with properties like `button: true` and a descriptive `label` to ensure proper screen reader support.
+## 2024-05-18 - Semantics for Custom InkWell Buttons
+**Learning:** Custom interactive elements using `InkWell` without built-in button wrappers lack accessibility semantics by default, making them difficult to interact with using screen readers.
+**Action:** When building custom buttons using `InkWell`, always wrap them in a `Semantics` widget with `button: true` and a descriptive `label` so screen reader users understand their purpose and interactivity.

--- a/lib/features/gallery/presentation/widgets/empty_gallery_illustration.dart
+++ b/lib/features/gallery/presentation/widgets/empty_gallery_illustration.dart
@@ -124,24 +124,28 @@ class GradientCTAButton extends StatelessWidget {
           ),
         ],
       ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onPressed,
-          borderRadius: BorderRadius.circular(14),
-          child: Center(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(icon, color: Colors.white, size: 20),
-                const SizedBox(width: 8),
-                Text(
-                  label,
-                  style: AppTypography.buttonLarge.copyWith(
-                    color: Colors.white,
+      child: Semantics(
+        button: true,
+        label: label,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(14),
+            child: Center(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, color: Colors.white, size: 20),
+                  const SizedBox(width: 8),
+                  Text(
+                    label,
+                    style: AppTypography.buttonLarge.copyWith(
+                      color: Colors.white,
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
💡 What: Added Semantics wrapper to GradientCTAButton.
🎯 Why: Custom InkWell buttons lack semantics by default, making them inaccessible to screen readers.
📸 Before/After: No visual change.
♿ Accessibility: Enables screen readers to identify it as a button and read its label.

---
*PR created automatically by Jules for task [7518161438428611694](https://jules.google.com/task/7518161438428611694) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Semantics` wrapper to the empty gallery CTA (`GradientCTAButton`) so screen readers announce it as a button with its label. No UI changes; improves accessibility of the custom `InkWell` button.

- **Bug Fixes**
  - Wrap `GradientCTAButton`’s `InkWell` in `Semantics(button: true, label: label)` to enable proper screen reader support.

<sup>Written for commit c3f95e5d25d8cb338107449d87f5682bed3e8b60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

