### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in webhook validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** Edge Functions (`delete-account`, `generate-image`, `reward-ad`) were catching all exceptions and returning `error.message` in 500 error responses, potentially leaking stack traces or internal environment details to clients.
 **Learning:** Returning raw Error messages in HTTP 500 responses is an information disclosure risk (CWE-209). While developers need this for debugging, clients should only receive a generic message.
 **Prevention:** In top-level catch blocks of API handlers or Edge Functions, always log the detailed error internally (e.g., `console.error`) and return a generic error message (e.g., `"Internal server error"`) to the client.
+
+## 2024-05-18 - Prevent Timing Attacks in Secret Validation
+**Vulnerability:** A manual XOR loop in TypeScript was used to validate the `REVENUECAT_WEBHOOK_SECRET` in `revenuecat-webhook`. While logically correct, JIT compilers (like V8 used by Deno) can optimize such loops unpredictably, potentially breaking constant-time execution and allowing timing attacks.
+**Learning:** Native cryptographic methods implemented in C++/Rust are necessary to guarantee timing safety in JS/TS environments. The Edge Runtime provides `timingSafeEqual` as a non-standard addition on `crypto.subtle`.
+**Prevention:** Always use `(crypto.subtle as any).timingSafeEqual(a, b)` for secret validation in Supabase Edge Functions instead of manually implementing bitwise XOR loops. Ensure a prior length check (`a.length === b.length`) is made, as native `timingSafeEqual` typically requires equal-length buffers.

--- a/supabase/functions/revenuecat-webhook/index.ts
+++ b/supabase/functions/revenuecat-webhook/index.ts
@@ -42,9 +42,8 @@ Deno.serve(async (req) => {
     });
   }
 
-  // Verify webhook auth header (no early-exit XOR comparison — length and bytes both checked).
-  // crypto.subtle.timingSafeEqual is available in Deno via type cast (see IAP SKILL.md Gotcha #11)
-  // but we use a manual XOR loop here — simpler, zero deps, and equally timing-safe.
+  // Verify webhook auth header securely.
+  // crypto.subtle.timingSafeEqual is available in Deno via type cast (see IAP SKILL.md Gotcha #11).
   // RC sends the Authorization header value EXACTLY as configured in the dashboard (no auto-added
   // "Bearer " prefix). Store just the raw token in REVENUECAT_WEBHOOK_SECRET and compare directly.
   const authHeader = req.headers.get("Authorization");
@@ -52,10 +51,12 @@ Deno.serve(async (req) => {
   const encoder = new TextEncoder();
   const a = encoder.encode(authHeader ?? "");
   const b = encoder.encode(expectedAuth);
-  let diff = a.length ^ b.length;
-  const len = Math.min(a.length, b.length);
-  for (let i = 0; i < len; i++) diff |= a[i] ^ b[i];
-  const authValid = authHeader !== null && diff === 0;
+
+  // Cast to any to access timingSafeEqual which is available in edge-runtime
+  const authValid = authHeader !== null &&
+    a.length === b.length &&
+    (crypto.subtle as any).timingSafeEqual(a, b);
+
   if (!authValid) {
     console.error(
       "[revenuecat-webhook] Invalid or missing authorization header",


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `revenuecat-webhook` edge function used a manual TypeScript XOR loop to perform timing-safe string comparison for its webhook secret. However, JIT compilers (like V8) can optimize manual bitwise loops unpredictably, potentially breaking constant-time execution guarantees and exposing the system to timing attacks.
🎯 Impact: An attacker could potentially deduce the webhook secret by carefully measuring the response times of validation failures, leading to unauthorized credit grants.
🔧 Fix: Replaced the manual XOR loop with the native C++/Rust-backed `(crypto.subtle as any).timingSafeEqual(a, b)` function provided by the Edge Runtime. Added an explicit `a.length === b.length` check prior to execution, as native implementations typically throw exceptions for unequal lengths.
✅ Verification: Ran `deno check` locally and ensured the logic successfully falls back to checking length before timing equality. Tests continue to pass.

---
*PR created automatically by Jules for task [15763976086142788670](https://jules.google.com/task/15763976086142788670) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timing attack risk in `revenuecat-webhook` by switching to a native, constant‑time comparison for the webhook secret. Prevents potential secret leakage and unauthorized credit grants.

- **Bug Fixes**
  - Replaced manual XOR comparison with `(crypto.subtle as any).timingSafeEqual` and an explicit length check in `supabase/functions/revenuecat-webhook/index.ts` for validating the `Authorization` header against `REVENUECAT_WEBHOOK_SECRET`.
  - Added guidance in `.jules/sentinel.md` to always use `timingSafeEqual` (with a prior length check) for secret validation.

<sup>Written for commit 6d60eb347d4c6295769fb20cc32e4646af155f50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

