### PR TITLE
⚡ Bolt: Prevent unnecessary CreateScreen rebuilds using Riverpod select

### DIFF
--- a/lib/features/create/presentation/create_screen.dart
+++ b/lib/features/create/presentation/create_screen.dart
@@ -164,12 +164,14 @@ class _CreateScreenState extends ConsumerState<CreateScreen> {
       createViewModelProvider.select(CreateViewModel.isJobActive),
     );
 
-    final isPremium = ref
-        .watch(authViewModelProvider)
-        .maybeMap(
-          authenticated: (state) => state.user.isPremium,
+    final isPremium = ref.watch(
+      authViewModelProvider.select(
+        (state) => state.maybeMap(
+          authenticated: (s) => s.user.isPremium,
           orElse: () => false,
-        );
+        ),
+      ),
+    );
 
     final promptLength = formState.prompt.trim().length;
     final showPromptError = !formState.isValid && formNotifier.hasInteracted;


### PR DESCRIPTION
💡 What: Changed `ref.watch(authViewModelProvider).maybeMap(...)` to `ref.watch(authViewModelProvider.select(...))` in `CreateScreen`.
🎯 Why: `authViewModelProvider` holds the entire authentication state. Watching it directly meant `CreateScreen` would rebuild whenever *any* auth property changed (e.g. token refresh, display name change, sign-in date update).
📊 Impact: Prevents expensive, unnecessary re-renders of the heavy `CreateScreen` widget tree. The widget now only rebuilds if the user's `isPremium` status specifically changes.
🔬 Measurement: Use Flutter DevTools' Performance/Widget Inspector to verify that `CreateScreen` no longer rebuilds during silent token refreshes or unrelated profile updates.

---
*PR created automatically by Jules for task [7974130407018949638](https://jules.google.com/task/7974130407018949638) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce unnecessary `CreateScreen` rebuilds by selecting only the `isPremium` auth field via `ref.watch(authViewModelProvider.select(...))`. This avoids rerenders on unrelated auth updates and improves screen performance.

- **Refactors**
  - Replaced `ref.watch(authViewModelProvider).maybeMap(...)` with `ref.watch(authViewModelProvider.select(...))`.
  - `CreateScreen` now rebuilds only when `user.isPremium` changes.

<sup>Written for commit 09fd7d030633dc69737223d942316cbc0b37acee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

