### PR TITLE
🎨 Palette: Add Semantics to custom InkWell icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2025-03-04 - Accessibility semantics for InkWell
 **Learning:** `InkWell` components in Flutter do not automatically provide accessibility semantics by default (unlike built-in `ElevatedButton`, `TextButton`, etc.). This causes screen readers to potentially skip interactive areas built with `InkWell`.
 **Action:** Always wrap `InkWell` widgets in a `Semantics` widget with `button: true` and an appropriate descriptive `label` to ensure correct screen reader behavior.
+## 2025-03-04 - Tooltip and Semantics on custom icon buttons
+**Learning:** Adding `Semantics(button: true, label: ...)` to an `InkWell` that only contains an icon is necessary when we are creating custom buttons (like `_GlassIconButton` or a remove icon overlaid on an image). Without it, the screen reader does not announce the action properly.
+**Action:** Always wrap custom icon-only interactive elements (like `InkWell` around an `Icon`) in `Semantics` with a descriptive label.

--- a/lib/features/gallery/presentation/widgets/image_info_bottom_sheet.dart
+++ b/lib/features/gallery/presentation/widgets/image_info_bottom_sheet.dart
@@ -181,20 +181,24 @@ class _GlassIconButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Tooltip(
       message: tooltip ?? '',
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          borderRadius: BorderRadius.circular(10),
-          onTap: onTap,
-          child: Container(
-            width: 38,
-            height: 38,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(10),
-              color: AppColors.white10,
-              border: Border.all(color: AppColors.white10, width: 0.5),
+      child: Semantics(
+        button: true,
+        label: tooltip ?? 'Button',
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(10),
+            onTap: onTap,
+            child: Container(
+              width: 38,
+              height: 38,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                color: AppColors.white10,
+                border: Border.all(color: AppColors.white10, width: 0.5),
+              ),
+              child: Icon(icon, color: Colors.white70, size: 18),
             ),
-            child: Icon(icon, color: Colors.white70, size: 18),
           ),
         ),
       ),

--- a/lib/shared/widgets/image_input_widget.dart
+++ b/lib/shared/widgets/image_input_widget.dart
@@ -126,20 +126,25 @@ class _ImagePreview extends StatelessWidget {
         Positioned(
           top: 8,
           right: 8,
-          child: Material(
-            color: theme.colorScheme.surface.withAlpha(200),
-            shape: const CircleBorder(),
-            child: Tooltip(
-              message: 'Remove image',
-              child: InkWell(
-                customBorder: const CircleBorder(),
-                onTap: onRemove,
-                child: Padding(
-                  padding: const EdgeInsets.all(6),
-                  child: Icon(
-                    Icons.close,
-                    size: 18,
-                    color: theme.colorScheme.onSurface,
+          child: Semantics(
+            button: true,
+            label: 'Remove image',
+            child: Material(
+              color: theme.colorScheme.surface.withAlpha(200),
+              shape: const CircleBorder(),
+              child: Tooltip(
+                message: 'Remove image',
+                excludeFromSemantics: true,
+                child: InkWell(
+                  customBorder: const CircleBorder(),
+                  onTap: onRemove,
+                  child: Padding(
+                    padding: const EdgeInsets.all(6),
+                    child: Icon(
+                      Icons.close,
+                      size: 18,
+                      color: theme.colorScheme.onSurface,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
💡 **What:** Added `Semantics` wrappers to custom `InkWell` icon-only buttons (`_GlassIconButton` and the remove image button).
🎯 **Why:** To ensure screen readers announce these interactive elements properly. Without `Semantics`, custom `InkWell` components often lack appropriate accessibility roles and labels in Flutter.
♿ **Accessibility:** Improved screen reader support for the image info bottom sheet and the image input remove functionality by assigning them a `button` role and descriptive labels.

---
*PR created automatically by Jules for task [15350309046039900615](https://jules.google.com/task/15350309046039900615) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Semantics to custom `InkWell` icon-only buttons so screen readers announce them as buttons with clear labels. Improves accessibility for image info actions and the image remove control.

- **Bug Fixes**
  - Wrapped `_GlassIconButton` in `Semantics(button: true, label: tooltip ?? 'Button')` in `image_info_bottom_sheet.dart`.
  - Wrapped the image remove icon in `Semantics(button: true, label: 'Remove image')` and set `Tooltip(excludeFromSemantics: true)` in `image_input_widget.dart`.
  - Added a note to `.jules/palette.md` on using `Semantics` for custom icon buttons.

<sup>Written for commit 81c66d9b1e8744e2c104adf1cff2b363b47cdc5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

