### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -23,3 +23,8 @@
 **Vulnerability:** A manual XOR loop in TypeScript was used to validate the `REVENUECAT_WEBHOOK_SECRET` in `revenuecat-webhook`. While logically correct, JIT compilers (like V8 used by Deno) can optimize such loops unpredictably, potentially breaking constant-time execution and allowing timing attacks.
 **Learning:** Native cryptographic methods implemented in C++/Rust are necessary to guarantee timing safety in JS/TS environments. The Edge Runtime provides `timingSafeEqual` as a non-standard addition on `crypto.subtle`.
 **Prevention:** Always use `(crypto.subtle as any).timingSafeEqual(a, b)` for secret validation in Supabase Edge Functions instead of manually implementing bitwise XOR loops. Ensure a prior length check (`a.length === b.length`) is made, as native `timingSafeEqual` typically requires equal-length buffers.
+
+## 2024-10-25 - Explicit HTTP Method Validation in Edge Functions
+**Vulnerability:** The `generate-image` Edge Function was missing explicit validation of the HTTP method (e.g., checking for `POST`). This could lead to unexpected behavior if a client sent a `GET` request, potentially triggering unhandled exceptions during JSON parsing and leaking internal errors.
+**Learning:** All Supabase Edge Functions should explicitly validate the incoming HTTP request method early in their execution flow.
+**Prevention:** Always include `if (req.method !== 'POST') { return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: ... }); }` immediately after CORS handling in POST-only endpoints.

--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -610,6 +610,13 @@ Deno.serve(async (req) => {
 
   const headers = corsHeaders();
 
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { ...headers, "Content-Type": "application/json" },
+    });
+  }
+
   try {
     // Extract userId from JWT token (not from request body)
     const authHeader = req.headers.get("Authorization");


### PR DESCRIPTION
💡 **Vulnerability**: The `generate-image` Edge Function was missing explicit validation of the HTTP method (e.g., checking for `POST`). This could lead to unexpected behavior if a client sent a `GET` request, potentially triggering unhandled exceptions during JSON parsing and leaking internal errors.
🎯 **Impact**: Improved robustness and prevention of unexpected execution paths.
🔧 **Fix**: Added `if (req.method !== 'POST')` check, returning a standard `405 Method Not Allowed` JSON response if the method is incorrect.
✅ **Verification**: Code verified using `deno check` and validated against other similar edge functions which follow this pattern.

---
*PR created automatically by Jules for task [13302489324555373784](https://jules.google.com/task/13302489324555373784) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce POST-only access for the `generate-image` Edge Function to prevent non-POST requests from reaching JSON parsing and error paths. Non-POST methods now return a 405 with a JSON error and CORS headers.

<sup>Written for commit bf43d3e48b7b359d9d2560df291ede685cbcb356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

