### PR TITLE
⚡ Bolt: Prevent unnecessary rebuilds with Riverpod select

### DIFF
--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -55,10 +55,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authState = ref.watch(authViewModelProvider);
-    final isLoading = authState is AuthStateAuthenticating;
+    final isLoading = ref.watch(
+      authViewModelProvider.select((state) => state is AuthStateAuthenticating),
+    );
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    Log.d('[LoginScreen] build — authState: $authState, isLoading: $isLoading');
+    Log.d('[LoginScreen] build — isLoading: $isLoading');
 
     ref.listen<AuthState>(authViewModelProvider, (_, state) {
       if (state is AuthStateError) {

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -50,8 +50,9 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authState = ref.watch(authViewModelProvider);
-    final isLoading = authState is AuthStateAuthenticating;
+    final isLoading = ref.watch(
+      authViewModelProvider.select((state) => state is AuthStateAuthenticating),
+    );
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     ref.listen<AuthState>(authViewModelProvider, (_, state) {

--- a/lib/features/create/presentation/widgets/credit_balance_chip.dart
+++ b/lib/features/create/presentation/widgets/credit_balance_chip.dart
@@ -13,9 +13,12 @@ class CreditBalanceChip extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final isLoggedIn = ref
-        .watch(authViewModelProvider)
-        .maybeMap(authenticated: (_) => true, orElse: () => false);
+    final isLoggedIn = ref.watch(
+      authViewModelProvider.select(
+        (state) =>
+            state.maybeMap(authenticated: (_) => true, orElse: () => false),
+      ),
+    );
     if (!isLoggedIn) return const SizedBox.shrink();
 
     return Padding(

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -170,23 +170,35 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final authState = ref.watch(authViewModelProvider);
-    final subStatus = ref.watch(subscriptionNotifierProvider);
-    final isLoggedIn = authState.maybeMap(
-      authenticated: (_) => true,
-      orElse: () => false,
+    final isLoggedIn = ref.watch(
+      authViewModelProvider.select(
+        (state) =>
+            state.maybeMap(authenticated: (_) => true, orElse: () => false),
+      ),
     );
-    final email = authState.maybeMap(
-      authenticated: (s) => s.user.email,
-      orElse: () => '',
+    final email = ref.watch(
+      authViewModelProvider.select(
+        (state) => state.maybeMap(
+          authenticated: (s) => s.user.email,
+          orElse: () => '',
+        ),
+      ),
     );
     // Prefer RevenueCat SDK data (immediate) over DB value (webhook-dependent).
     // Falls back to DB if RevenueCat hasn't loaded yet.
     final isPremium =
-        subStatus.valueOrNull?.isActive ??
-        authState.maybeMap(
-          authenticated: (s) => s.user.isPremium,
-          orElse: () => false,
+        ref.watch(
+          subscriptionNotifierProvider.select(
+            (state) => state.valueOrNull?.isActive,
+          ),
+        ) ??
+        ref.watch(
+          authViewModelProvider.select(
+            (state) => state.maybeMap(
+              authenticated: (s) => s.user.isPremium,
+              orElse: () => false,
+            ),
+          ),
         ) ??
         false;
     final isDark = Theme.of(context).brightness == Brightness.dark;

--- a/lib/features/template_engine/presentation/screens/template_detail_screen.dart
+++ b/lib/features/template_engine/presentation/screens/template_detail_screen.dart
@@ -264,12 +264,14 @@ class _TemplateDetailScreenState extends ConsumerState<TemplateDetailScreen> {
     final templateAsync = ref.watch(templateByIdProvider(widget.templateId));
     final jobAsync = ref.watch(generationViewModelProvider);
     final options = ref.watch(generationOptionsProvider);
-    final isPremium = ref
-        .watch(authViewModelProvider)
-        .maybeMap(
+    final isPremium = ref.watch(
+      authViewModelProvider.select(
+        (state) => state.maybeMap(
           authenticated: (state) => state.user.isPremium,
           orElse: () => false,
-        );
+        ),
+      ),
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('Generate')),


### PR DESCRIPTION
💡 What: Updated `SettingsScreen`, `TemplateDetailScreen`, `CreditBalanceChip`, `LoginScreen`, and `RegisterScreen` to use Riverpod's `.select()` method when watching complex state providers like `authViewModelProvider` and `subscriptionNotifierProvider`.
🎯 Why: Previously, these widgets were watching the entirety of complex state objects. This caused expensive, unnecessary rebuilds of heavy UI components (such as entire settings screens and template details) whenever completely unrelated sub-properties of that state changed.
📊 Impact: Eliminates unnecessary full widget tree rebuilds triggered by unrelated state changes. For example, `SettingsScreen` now only rebuilds if the user's `isLoggedIn` status, `email`, or `isPremium` status specifically changes, preventing jank during unrelated authentication state updates.
🔬 Measurement: Use the Flutter DevTools Performance view and Widget Inspector. Observe that interacting with unrelated global state no longer triggers rebuilds for these components.

---
*PR created automatically by Jules for task [12692685927976625184](https://jules.google.com/task/12692685927976625184) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `riverpod` .select() to avoid full widget rebuilds when auth or subscription state changes, improving UI smoothness across key screens.
Only relevant fields now trigger rebuilds (e.g., isLoading, isLoggedIn, email, isPremium).

- **Refactors**
  - Switched to `.select()` in `SettingsScreen`, `TemplateDetailScreen`, `CreditBalanceChip`, `LoginScreen`, and `RegisterScreen`.
  - Narrow watches to specific slices: `isLoading`, `isLoggedIn`, `email`, and `isPremium` (prefers `subscriptionNotifierProvider`’s `isActive`, falls back to `authViewModelProvider`).
  - Trimmed build log noise in `LoginScreen`.

<sup>Written for commit e4017d825330d9f50a89cb3a8a9c06bff72dde06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

