### PR TITLE
⚡ Bolt: Prevent unnecessary rebuilds with select

### DIFF
--- a/lib/features/gallery/presentation/pages/image_viewer_page.dart
+++ b/lib/features/gallery/presentation/pages/image_viewer_page.dart
@@ -231,9 +231,14 @@ class _ImageViewerPageState extends ConsumerState<ImageViewerPage>
   Widget build(BuildContext context) {
     const kOpacityFadeStart = 100.0;
     const kOpacityFadeRange = 200.0;
-    final showWatermark = ref
-        .watch(subscriptionNotifierProvider)
-        .maybeWhen(data: (status) => status.isFree, orElse: () => true);
+    final showWatermark = ref.watch(
+      subscriptionNotifierProvider.select(
+        (state) => state.maybeWhen(
+          data: (status) => status.isFree,
+          orElse: () => true,
+        ),
+      ),
+    );
     final viewerOpacity = (_dragOffset.abs() > kOpacityFadeStart)
         ? (1.0 -
               ((_dragOffset.abs() - kOpacityFadeStart) / kOpacityFadeRange)


### PR DESCRIPTION
💡 **What**: Used `.select()` on `subscriptionNotifierProvider` in `ImageViewerPage` to watch only the `isFree` derived state instead of the entire `SubscriptionStatus` object.

🎯 **Why**: To prevent unnecessary and expensive rebuilds of the heavy `ImageViewerPage` widget tree when unrelated properties of the subscription state change.

📊 **Impact**: Eliminates redundant rebuilds of the full-screen image viewer, saving CPU cycles and reducing potential jank during state updates.

🔬 **Measurement**: Verify via Flutter DevTools Performance view that `ImageViewerPage` does not rebuild when subscription state changes trigger updates to non-`isFree` properties.

---
*PR created automatically by Jules for task [9785440196778512002](https://jules.google.com/task/9785440196778512002) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Used `.select()` on `subscriptionNotifierProvider` in `ImageViewerPage` to watch only the derived `isFree` state and prevent unnecessary rebuilds. This keeps the full-screen image viewer from rebuilding when unrelated subscription fields change, reducing jank.

<sup>Written for commit 14c73628e3399cb48b2ce71016e82f12153c9db4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

