### PR TITLE
🛡️ Sentinel: [security improvement] Enforce POST on reward-ad endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -28,3 +28,7 @@
 **Vulnerability:** The `generate-image` Edge Function was missing explicit validation of the HTTP method (e.g., checking for `POST`). This could lead to unexpected behavior if a client sent a `GET` request, potentially triggering unhandled exceptions during JSON parsing and leaking internal errors.
 **Learning:** All Supabase Edge Functions should explicitly validate the incoming HTTP request method early in their execution flow.
 **Prevention:** Always include `if (req.method !== 'POST') { return new Response(JSON.stringify({ error: 'Method not allowed' }), { status: 405, headers: ... }); }` immediately after CORS handling in POST-only endpoints.
+## 2024-05-15 - Missing HTTP Method Validation in Edge Function
+**Vulnerability:** The `reward-ad` Edge Function did not validate the HTTP method (`req.method`) for its main actions (`request-nonce` and `claim`), allowing non-POST requests to execute potentially state-modifying logic.
+**Learning:** Default unhandled methods in Supabase Edge Functions do not automatically reject unless explicitly checked, meaning endpoints intended for POST could be accessed via GET or other methods, increasing the risk of CSRF or unintended execution.
+**Prevention:** Always explicitly validate the expected HTTP method (e.g., `if (req.method !== "POST")`) at the start of the handler and return a `405 Method Not Allowed` response if the condition is not met.

--- a/supabase/functions/reward-ad/index.ts
+++ b/supabase/functions/reward-ad/index.ts
@@ -471,6 +471,13 @@ Deno.serve(async (req) => {
       );
     }
 
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...headers, "Content-Type": "application/json" },
+      });
+    }
+
     const supabase = getSupabaseClient();
     const authResult = await authenticateUser(req, supabase);
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `reward-ad` Edge Function was missing explicit HTTP method validation for its state-modifying actions (`request-nonce` and `claim`). This meant these endpoints could be invoked via arbitrary HTTP methods (like GET), potentially opening them up to CSRF or unexpected execution patterns.
🎯 **Impact:** While protected by authentication, allowing non-POST methods on actions that generate nonces or claim credits violates the principle of least privilege and safe HTTP semantics, increasing the attack surface.
🔧 **Fix:** Added an explicit `req.method !== "POST"` check returning a `405 Method Not Allowed` early in the request lifecycle (matching the pattern in other Edge Functions).
✅ **Verification:** Verified code patch applies cleanly and returns 405 for non-POST methods. Flutter test suite still passes successfully.

---
*PR created automatically by Jules for task [16654263590772586067](https://jules.google.com/task/16654263590772586067) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce POST-only access for `reward-ad` actions (`request-nonce`, `claim`), returning 405 for non-POST requests to reduce CSRF risk and follow safe HTTP semantics. Adds an early method check and updates Sentinel documentation.

<sup>Written for commit 28999ca1838490251138bb84e1688958813da099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

