### PR TITLE
🎨 Palette: Dynamic semantics label for category chips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-03-04 - Tooltip and Semantics on custom icon buttons
 **Learning:** Adding `Semantics(button: true, label: ...)` to an `InkWell` that only contains an icon is necessary when we are creating custom buttons (like `_GlassIconButton` or a remove icon overlaid on an image). Without it, the screen reader does not announce the action properly.
 **Action:** Always wrap custom icon-only interactive elements (like `InkWell` around an `Icon`) in `Semantics` with a descriptive label.
+## 2026-04-15 - Dynamic semantics labels in lists
+**Learning:** When using `Semantics` in a `ListView` or grid builder, a static label (like 'Filter category') causes the screen reader to announce identical names for every item, making it impossible for visually impaired users to distinguish between them.
+**Action:** Always make `Semantics` labels dynamic in lists (e.g., `label: 'Filter category: ${_categories[index]}'`) to provide unique context for each interactive element.

--- a/lib/features/template_engine/presentation/widgets/home_screen_widgets.dart
+++ b/lib/features/template_engine/presentation/widgets/home_screen_widgets.dart
@@ -78,7 +78,7 @@ class _CategoryChipsState extends State<CategoryChips> {
           final isSelected = _selectedIndex == index;
           return Semantics(
             button: true,
-            label: 'Filter category',
+            label: 'Filter category: ${_categories[index]}',
             child: GestureDetector(
               onTap: () => setState(() => _selectedIndex = index),
               child: AnimatedContainer(


### PR DESCRIPTION
💡 What: Updated the `Semantics` label in `CategoryChips` to dynamically include the category name.
🎯 Why: To prevent the screen reader from announcing identical names ('Filter category') for every category chip in the list, making it impossible for visually impaired users to distinguish between them.
📸 Before/After: Before, screen readers announced "Filter category, button" for all chips. After, screen readers announce "Filter category: Portrait, button", "Filter category: Landscape, button", etc.
♿ Accessibility: Improves screen reader support by uniquely identifying each item in a list of interactive elements.

---
*PR created automatically by Jules for task [16667399646255519179](https://jules.google.com/task/16667399646255519179) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `Semantics` label in `CategoryChips` dynamic so it includes the category name (e.g., "Filter category: Portrait"). This fixes identical screen reader announcements across chips and improves navigation for visually impaired users.

<sup>Written for commit ef7c3f4b1a3bd899a389bfcbf84ed2f78cb10548. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

