### PR TITLE
🎨 Palette: Improve dialog UX for image viewer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-03-04 - Tooltip and Semantics on custom icon buttons
 **Learning:** Adding `Semantics(button: true, label: ...)` to an `InkWell` that only contains an icon is necessary when we are creating custom buttons (like `_GlassIconButton` or a remove icon overlaid on an image). Without it, the screen reader does not announce the action properly.
 **Action:** Always wrap custom icon-only interactive elements (like `InkWell` around an `Icon`) in `Semantics` with a descriptive label.
+## 2025-03-04 - UX pattern for destructive dialog actions
+**Learning:** Using a simple `TextButton` with red text for destructive actions (like "Delete") in dialogs provides weak visual distinction and poor accessibility cues for critical actions.
+**Action:** Use a `FilledButton` (or `FilledButton.icon` to be even clearer) with a strong color background (e.g., `Colors.red`) and contrasting text (`Colors.white`) for destructive actions to ensure users clearly recognize the severity of the action before confirming.

--- a/lib/features/gallery/presentation/pages/image_viewer_page.dart
+++ b/lib/features/gallery/presentation/pages/image_viewer_page.dart
@@ -116,9 +116,10 @@ class _ImageViewerPageState extends ConsumerState<ImageViewerPage>
               onPressed: () => Navigator.of(context).pop(false),
               child: const Text('Cancel'),
             ),
-            FilledButton(
+            FilledButton.icon(
               onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('Download Anyway'),
+              icon: const Icon(Icons.download_rounded, size: 18),
+              label: const Text('Download Anyway'),
             ),
           ],
         ),
@@ -181,10 +182,14 @@ class _ImageViewerPageState extends ConsumerState<ImageViewerPage>
             onPressed: () => Navigator.of(context).pop(false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.of(context).pop(true),
-            style: TextButton.styleFrom(foregroundColor: Colors.red),
-            child: const Text('Delete'),
+            style: FilledButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.delete_outline_rounded, size: 18),
+            label: const Text('Delete'),
           ),
         ],
       ),


### PR DESCRIPTION
💡 **What**: Upgraded the generic `TextButton` used for the "Delete" action in the image viewer to a more prominent `FilledButton.icon` styled in red. Also added a download icon to the "Download Anyway" button in the watermark warning dialog.
🎯 **Why**: Using simple text buttons for destructive actions like deleting an image provides weak visual warnings, potentially leading to accidental deletions. The upgrade to a strongly-styled filled button with an icon immediately signals the severity of the action to users. Adding an icon to the download dialog enhances visual clarity.
📸 **Before/After**: The "Delete" button went from being a plain text button with red text to a solid red button with white text and a trash icon. The "Download Anyway" button gained a download icon.
♿ **Accessibility**: The added icons act as visual cues for the button actions. Recorded the pattern for clear destructive actions in the Palette journal.

---
*PR created automatically by Jules for task [3097688172734564995](https://jules.google.com/task/3097688172734564995) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved image viewer dialogs to reduce accidental actions by turning "Delete" into a red `FilledButton.icon` with a trash icon and white text, and switching "Download Anyway" to `FilledButton.icon` with a download icon. Documented the destructive-action button pattern in `.jules/palette.md`.

<sup>Written for commit c8a5b89c1e625fd75fe87cca948a70713ebb42a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

