### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in generate-image function

### DIFF
--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -101,7 +101,7 @@ const SIGNED_URL_EXPIRY_SECONDS = 3600; // 1 hour
 /**
  * Resolve image inputs to publicly accessible URLs.
  * - Supabase storage paths (no protocol) → signed URLs
- * - Already full URLs (http/https) → passed through unchanged
+ * - Already full URLs (http/https) → passed through unchanged if valid
  */
 async function resolveImageUrls(
   supabase: ReturnType<typeof getSupabaseClient>,
@@ -110,8 +110,30 @@ async function resolveImageUrls(
   return Promise.all(
     imageInputs.map(async (input) => {
       if (input.startsWith("http://") || input.startsWith("https://")) {
+        // Block known private networks and metadata endpoints to prevent SSRF
+        try {
+          const url = new URL(input);
+          const hostname = url.hostname.toLowerCase();
+          const invalidHostnames = ['localhost', '127.0.0.1', '::1', '169.254.169.254'];
+
+          if (invalidHostnames.includes(hostname)) {
+            throw new Error("Invalid URL");
+          }
+
+          // Pattern match for local network IP spaces to prevent accessing internal services
+          if (/^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
+              /^192\.168\.\d{1,3}\.\d{1,3}$/.test(hostname) ||
+              /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/.test(hostname)) {
+            throw new Error("Invalid URL");
+          }
+        } catch (e) {
+          throw new Error("Invalid URL provided to resolveImageUrls");
+        }
         return input;
       } else {
+        if (input.includes("../") || input.includes("..\\")) {
+          throw new Error("Path traversal is not allowed in image inputs.");
+        }
         // Treat as Supabase storage path — generate signed URL
         const { data, error } = await supabase.storage
           .from(STORAGE_BUCKET)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: 
1. **Server-Side Request Forgery (SSRF)**: The `resolveImageUrls` function allowed users to provide arbitrary external HTTP/HTTPS URLs as image inputs. These URLs were subsequently fetched by the edge function (`downloadImageAsBase64` / `downloadImage`) or the KIE API without validation, potentially allowing an attacker to bypass firewalls and access internal services or metadata endpoints (e.g., `http://169.254.169.254/latest/meta-data/` on AWS or `http://localhost/`).
2. **Path Traversal**: When an input did not begin with HTTP/HTTPS, it was assumed to be a Supabase storage path. An attacker could provide a path containing `../` to access files outside their intended directory structure.

🎯 **Impact**:
*   **SSRF**: Could lead to unauthorized access to internal services, cloud metadata exposure, or reconnaissance on the internal network.
*   **Path Traversal**: Could allow an attacker to generate signed URLs for or manipulate other users' files within the storage bucket.

🔧 **Fix**:
*   **SSRF Mitigation**: Modified `resolveImageUrls` to parse external URLs using the native `URL` class (which normalizes obfuscated IP formats) and strictly block hostnames that match known private or restricted IP spaces (e.g., `localhost`, `127.0.0.1`, `169.254.169.254`, `10.0.0.0/8`, `192.168.0.0/16`, `172.16.0.0/12`).
*   **Path Traversal Mitigation**: Explicitly reject paths containing `../` or `..\`.

✅ **Verification**:
*   Ran `npx deno check supabase/functions/generate-image/index.ts` to confirm TypeScript validation.
*   Ran `flutter test` to ensure existing functionality remains unbroken.

---
*PR created automatically by Jules for task [3712777412622650976](https://jules.google.com/task/3712777412622650976) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical SSRF and path traversal in the generate-image edge function. Blocks private/metadata URLs and rejects traversal in storage paths to protect internal resources.

- **Bug Fixes**
  - Validate external image URLs with `URL`; reject `localhost`, `127.0.0.1`, `::1`, `169.254.169.254`, and RFC1918 ranges (`10.x.x.x`, `192.168.x.x`, `172.16–31.x.x`).
  - Reject inputs containing `../` or `..\` to prevent path traversal in Supabase storage paths.
  - Preserve valid `http/https` URLs; continue generating signed URLs for storage paths.
  - Verified via `deno check` and existing tests (`flutter test`).

<sup>Written for commit 1f8195de96513557ac1403fdb42dca4431f7345b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

