### PR TITLE
⚡ Bolt: [performance improvement] Optimize Riverpod watchers using .select()

### DIFF
--- a/lib/features/gallery/presentation/providers/gallery_provider.dart
+++ b/lib/features/gallery/presentation/providers/gallery_provider.dart
@@ -9,10 +9,13 @@ part 'gallery_provider.g.dart';
 /// Stream provider for realtime gallery updates
 @riverpod
 Stream<List<GalleryItem>> galleryStream(Ref ref) {
-  final authState = ref.watch(authViewModelProvider);
-  final userId = authState.maybeMap(
-    authenticated: (s) => s.user.id,
-    orElse: () => null,
+  final userId = ref.watch(
+    authViewModelProvider.select(
+      (state) => state.maybeMap(
+        authenticated: (s) => s.user.id,
+        orElse: () => null,
+      ),
+    ),
   );
 
   if (userId == null) return Stream.value([]);

--- a/lib/features/subscription/presentation/providers/subscription_provider.dart
+++ b/lib/features/subscription/presentation/providers/subscription_provider.dart
@@ -18,11 +18,14 @@ class SubscriptionNotifier extends _$SubscriptionNotifier {
   @override
   Future<SubscriptionStatus> build() async {
     // Admin/DB-premium users bypass RevenueCat and get Ultra status.
-    final authState = ref.watch(authViewModelProvider);
-    final isDbPremium = switch (authState) {
-      AuthStateAuthenticated(user: final u) => u.isPremium,
-      _ => false,
-    };
+    final isDbPremium = ref.watch(
+      authViewModelProvider.select(
+        (state) => switch (state) {
+          AuthStateAuthenticated(user: final u) => u.isPremium,
+          _ => false,
+        },
+      ),
+    );
     if (isDbPremium) {
       return const SubscriptionStatus(
         tier: SubscriptionTiers.ultra,

--- a/lib/features/template_engine/presentation/screens/home_screen.dart
+++ b/lib/features/template_engine/presentation/screens/home_screen.dart
@@ -140,10 +140,9 @@ class _LowCreditBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final balance = ref
-        .watch(creditBalanceNotifierProvider)
-        .valueOrNull
-        ?.balance;
+    final balance = ref.watch(
+      creditBalanceNotifierProvider.select((state) => state.valueOrNull?.balance),
+    );
     final subscriptionAsync = ref.watch(subscriptionNotifierProvider);
 
     // Hide banner while subscription is loading or errored to avoid false alarm.


### PR DESCRIPTION
💡 **What:** 
Updated Riverpod `ref.watch` calls to use `.select()` in three key locations:
1. `galleryStream` provider to only watch `userId`.
2. `SubscriptionNotifier` to only watch `isPremium`.
3. `HomeScreen` to only watch the credit `balance`.

🎯 **Why:** 
Previously, these providers and widgets were watching entire complex state objects (like `authViewModelProvider` and `creditBalanceNotifierProvider`). Any minor, unrelated state change (e.g., a user updating their profile name or email) would trigger unnecessary recalculations, background fetches, or UI rebuilds. This optimization ensures that re-evaluations only occur when the specific properties we care about change.

📊 **Impact:** 
- Reduces unnecessary Riverpod provider recalculations and API calls.
- Avoids redundant widget rebuilds (e.g. `HomeScreen` rebuilding when credit history updates instead of just the balance).
- Enhances overall reactivity and responsiveness of the application, especially during authentication or user profile changes.

🔬 **Measurement:** 
- No regressions observed. `flutter test` and `flutter analyze` pass successfully.
- Code has been formatted.

---
*PR created automatically by Jules for task [7035571738453093571](https://jules.google.com/task/7035571738453093571) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize Riverpod watchers using .select() to observe only needed fields, reducing recalculations and widget rebuilds. Improves responsiveness and cuts unnecessary API calls.

- **Refactors**
  - `galleryStream`: watch `userId` from `authViewModelProvider` via `.select()`.
  - `SubscriptionNotifier`: watch `isPremium` only.
  - `HomeScreen` low-credit banner: watch credit `balance` from `creditBalanceNotifierProvider` only.

<sup>Written for commit de09912df5eb02738751447a8d835d48106812c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

