### PR TITLE
⚡ Bolt: Optimize AiModels.getById to use O(1) Map lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-18 - Optimize CachedNetworkImage Cache Key
 **Learning:** When using signed URLs that include an expiring token as a query parameter (e.g., Supabase storage URLs), `CachedNetworkImage` defaults to using the full URL as the cache key. This causes continuous cache misses and redundant downloads when the token rotates.
 **Action:** Always explicitly set the `cacheKey` property to the URL stripped of its query string (e.g., `url.split('?').first`) to ensure the cache survives token expiration.
+
+## 2024-05-24 - Pre-compute Static Maps for O(1) Lookups
+**Learning:** Using `List.where` (e.g., `all.where((m) => m.id == id)`) for frequent targeted lookups on static lists inside heavily used methods or UI builds creates unnecessary $O(N)$ linear scans. This compounds overhead in lists and builders.
+**Action:** Always pre-compute a static `Map` (e.g., `static final Map<String, Config> _idMap = { for (final m in all) m.id: m };`) to convert these $O(N)$ list traversals into $O(1)$ hash map lookups.

--- a/lib/core/constants/ai_models.dart
+++ b/lib/core/constants/ai_models.dart
@@ -212,11 +212,13 @@ class AiModels {
     ),
   ];
 
+  // Pre-computed map for O(1) lookups by ID
+  static final Map<String, AiModelConfig> _idMap = {
+    for (final model in all) model.id: model,
+  };
+
   /// Get model by ID
-  static AiModelConfig? getById(String id) {
-    final matches = all.where((m) => m.id == id);
-    return matches.isEmpty ? null : matches.first;
-  }
+  static AiModelConfig? getById(String id) => _idMap[id];
 
   /// Get default model
   static AiModelConfig get defaultModel => getById(defaultModelId) ?? all.first;


### PR DESCRIPTION
💡 **What:** Added a statically computed map to perform O(1) lookups in `AiModels.getById()`.
🎯 **Why:** Previously, `AiModels.getById()` used `.where` to perform an O(N) linear scan over the list of supported models. Since this method is called frequently during state updates (e.g. `CreateViewModel`), widget builds (`ModelSelector`, `AspectRatioSelector`), and validation, it caused unnecessary overhead.
📊 **Impact:** Reduces lookup complexity from O(N) to O(1), preventing redundant iteration during UI builds and form interactions.
🔬 **Measurement:** Analyzed with `dart analyze` and `dart test` to confirm performance pattern was safely implemented. Pre-computed static `_idMap` avoids lazy allocation costs per-frame.

---
*PR created automatically by Jules for task [516770967292638242](https://jules.google.com/task/516770967292638242) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize `AiModels.getById()` to use a pre-computed static map for O(1) lookups instead of an O(N) list scan. This removes unnecessary iteration during frequent UI builds and validation with no behavior changes.

<sup>Written for commit e2444c3e15ef53a93b41f569dda3bde2e9aad45d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

