### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal vulnerabilities in generate-image

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The `reward-ad` Edge Function did not validate the HTTP method (`req.method`) for its main actions (`request-nonce` and `claim`), allowing non-POST requests to execute potentially state-modifying logic.
 **Learning:** Default unhandled methods in Supabase Edge Functions do not automatically reject unless explicitly checked, meaning endpoints intended for POST could be accessed via GET or other methods, increasing the risk of CSRF or unintended execution.
 **Prevention:** Always explicitly validate the expected HTTP method (e.g., `if (req.method !== "POST")`) at the start of the handler and return a `405 Method Not Allowed` response if the condition is not met.
+
+## 2024-10-26 - SSRF and Path Traversal in Image Generation
+**Vulnerability:** The `generate-image` Edge Function accepted raw user input (`imageInputs`) and resolved them as either URLs or Supabase storage paths. The URL branch lacked validation, allowing Server-Side Request Forgery (SSRF) against internal metadata/local IP ranges. The storage branch lacked validation against path traversal (`../`), allowing access to files outside the intended user bucket.
+**Learning:** Functions that fetch external resources or read files based on user input must strictly validate the input format and destination, even when using signed URLs or authenticated clients.
+**Prevention:** Always parse URLs and validate hostnames against private/local IP ranges to prevent SSRF. Always check for `../` and `..\` sequences in relative file paths to prevent path traversal before accessing cloud storage.

--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -110,8 +110,33 @@ async function resolveImageUrls(
   return Promise.all(
     imageInputs.map(async (input) => {
       if (input.startsWith("http://") || input.startsWith("https://")) {
+        try {
+          const parsedUrl = new URL(input);
+          const hostname = parsedUrl.hostname.toLowerCase();
+
+          // Basic SSRF protection - reject private and metadata IP ranges
+          if (
+            hostname === "localhost" ||
+            hostname === "127.0.0.1" ||
+            hostname === "169.254.169.254" ||
+            hostname === "0.0.0.0" ||
+            hostname.startsWith("10.") ||
+            hostname.startsWith("192.168.") ||
+            hostname.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\./)
+          ) {
+            throw new Error(`Invalid URL hostname: ${hostname}`);
+          }
+        } catch (e) {
+          console.error(`[storage] Invalid URL provided: ${input}`, e);
+          throw new Error("Invalid image URL provided");
+        }
         return input;
       } else {
+        // Prevent path traversal
+        if (input.includes("../") || input.includes("..\\")) {
+          throw new Error("Invalid storage path provided");
+        }
+
         // Treat as Supabase storage path — generate signed URL
         const { data, error } = await supabase.storage
           .from(STORAGE_BUCKET)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `generate-image` Edge Function accepted raw user input (`imageInputs`) and resolved them without validation. This allowed Server-Side Request Forgery (SSRF) by supplying URLs pointing to internal/private IPs, and Path Traversal by supplying storage paths containing `../` or `..\`.
🎯 **Impact**: An attacker could potentially access internal network resources or read unauthorized files from the Supabase storage bucket, leading to data exfiltration or internal service compromise.
🔧 **Fix**: Added robust URL parsing and hostname validation to block private and metadata IP ranges (SSRF protection). Added explicit path traversal checks (`../` and `..\`) for storage paths.
✅ **Verification**: Run `npx deno check supabase/functions/generate-image/index.ts` and verify no type errors are present. The function will now explicitly reject requests to internal IPs and paths attempting traversal.

---
*PR created automatically by Jules for task [1273751583800367381](https://jules.google.com/task/1273751583800367381) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSRF and path traversal in `generate-image` by validating user-supplied image inputs. Blocks internal network access and prevents unauthorized file reads.

- **Bug Fixes**
  - Parse URLs and reject localhost, `127.0.0.1`, `169.254.169.254`, `0.0.0.0`, and private ranges (`10.*`, `192.168.*`, `172.16-31.*`).
  - Reject storage paths containing `../` or `..\`.
  - Log invalid inputs and return clear errors; valid URLs and paths continue to work.

<sup>Written for commit 8173e95228101abe8dc7955270cb7234486a8fd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

