### PR TITLE
🎨 Palette: [UX improvement] Enhance destructive dialog buttons

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -105,10 +105,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Delete'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.delete_outline_rounded, size: 18),
+            label: const Text('Delete'),
           ),
         ],
       ),
@@ -143,10 +147,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Logout'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.logout_rounded, size: 18),
+            label: const Text('Logout'),
           ),
         ],
       ),


### PR DESCRIPTION
💡 **What**: Replaced the simple `TextButton` used for confirm actions ("Delete" and "Logout") in the SettingsScreen confirmation dialogs with a `FilledButton.icon` featuring a red background (`AppColors.error`) and an appropriate icon.

🎯 **Why**: Using a simple text button for critical, destructive actions provides weak visual distinction. A strong red background makes it immediately obvious to the user that they are confirming a severe action (like deleting their account or logging out), reducing the chance of accidental clicks and improving the overall intuitiveness of the interface.

♿ **Accessibility**: Provides clearer visual contrast and hierarchy for destructive actions, aligning with common design patterns.

✅ **Verification**:
- `flutter analyze` passes
- `flutter test` for settings components passes

---
*PR created automatically by Jules for task [226923202640948960](https://jules.google.com/task/226923202640948960) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `TextButton` with `FilledButton.icon` in Settings confirmation dialogs for Delete and Logout, using an `AppColors.error` background, white text, and icons. This makes destructive actions clearly stand out, reducing accidental taps and improving accessibility.

<sup>Written for commit 156eaddfc12064fa6343c4e51817851aed675f62. Summary will update on new commits. <a href="https://cubic.dev/pr/monet88/artio/pull/148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

