### PR TITLE
🎨 Palette: [UX] Use FilledButton for destructive Delete Account action

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -105,10 +105,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Delete'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.delete_outline_rounded, size: 18),
+            label: const Text('Delete'),
           ),
         ],
       ),


### PR DESCRIPTION
💡 **What**: Replaced the `TextButton` for the "Delete" action in the `Delete Account` dialog with a `FilledButton.icon`.

🎯 **Why**: Using a simple `TextButton` with red text for destructive actions provides weak visual distinction and poor accessibility cues for critical actions. The `FilledButton.icon` with a solid red background provides a much clearer, high-contrast visual cue.

♿ **Accessibility**: Provides a higher contrast and a clearer visual indicator of the action's severity.

📸 **Before/After**:
Before: A simple TextButton with red text.
After: A FilledButton with an error red background, white text, and a trash outline icon.

---
*PR created automatically by Jules for task [5228607655136210915](https://jules.google.com/task/5228607655136210915) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the "Delete" action in the Delete Account dialog from a `TextButton` to a `FilledButton.icon` to make the destructive action obvious and accessible. Uses an error-red background, white text, and a delete icon for higher contrast and clearer affordance.

<sup>Written for commit 344f62bb776ebf3096cd16ca3911fab16c3d38b7. Summary will update on new commits. <a href="https://cubic.dev/pr/monet88/artio/pull/150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

