### PR TITLE
⚡ Bolt: Optimize AiModels lookups and getters

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,6 @@
 ## 2025-05-18 - Optimize CachedNetworkImage Cache Key
 **Learning:** When using signed URLs that include an expiring token as a query parameter (e.g., Supabase storage URLs), `CachedNetworkImage` defaults to using the full URL as the cache key. This causes continuous cache misses and redundant downloads when the token rotates.
 **Action:** Always explicitly set the `cacheKey` property to the URL stripped of its query string (e.g., `url.split('?').first`) to ensure the cache survives token expiration.
+## 2024-05-24 - Pre-compute filtered static lists
+**Learning:** Exposing dynamically filtered static lists as getters (`get filteredList => all.where(...).toList()`) causes redundant $O(N)$ filter evaluations and heap list allocations on every access (e.g., during UI rebuilds).
+**Action:** Convert filtered subset getters of static constant lists into `static final` fields to compute the filter exactly once and ensure $O(1)$ property access.

--- a/lib/core/constants/ai_models.dart
+++ b/lib/core/constants/ai_models.dart
@@ -212,11 +212,12 @@ class AiModels {
     ),
   ];
 
-  /// Get model by ID
-  static AiModelConfig? getById(String id) {
-    final matches = all.where((m) => m.id == id);
-    return matches.isEmpty ? null : matches.first;
-  }
+  static final Map<String, AiModelConfig> _byIdMap = {
+    for (final model in all) model.id: model,
+  };
+
+  /// Get model by ID (O(1) lookup)
+  static AiModelConfig? getById(String id) => _byIdMap[id];
 
   /// Get default model
   static AiModelConfig get defaultModel => getById(defaultModelId) ?? all.first;
@@ -226,13 +227,13 @@ class AiModels {
       all.where((m) => m.type == type).toList();
 
   /// Get text-to-image models only
-  static List<AiModelConfig> get textToImageModels => byType('text-to-image');
+  static final List<AiModelConfig> textToImageModels = byType('text-to-image');
 
   /// Get free models only
-  static List<AiModelConfig> get freeModels =>
+  static final List<AiModelConfig> freeModels =
       all.where((m) => !m.isPremium).toList();
 
   /// Get models that support image input
-  static List<AiModelConfig> get imageCapableModels =>
+  static final List<AiModelConfig> imageCapableModels =
       all.where((m) => m.supportsImageInput).toList();
 }


### PR DESCRIPTION
💡 What:
1. Replaced iterative `.where(...).first` in `AiModels.getById` with a pre-computed static Map for O(1) lookups.
2. Converted dynamic list getters (`textToImageModels`, `freeModels`, `imageCapableModels`) into `static final` fields.

🎯 Why:
The `getById` method was performing an O(N) iterative search on a list of models every time it was called (often multiple times per screen).
The filtered list getters were executing `.where(...).toList()` upon every access, redundantly traversing the list and allocating new lists in memory during UI rebuilds.

📊 Impact:
- Transforms O(N) model lookups into O(1) hash map lookups.
- Eliminates redundant list memory allocations and filter evaluations for the statically defined subset lists.

🔬 Measurement:
Run `flutter test test/core/` to verify that the lookups and filters function identically to their unoptimized versions.

---
*PR created automatically by Jules for task [847419036791902321](https://jules.google.com/task/847419036791902321) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `AiModels` lookups to O(1) and precomputed filtered model lists to avoid repeated allocations. This reduces per-build work and speeds UI rebuilds.

- **Refactors**
  - Replaced iterative `.where(...).first` in `AiModels.getById` with a static map.
  - Converted filtered getters to `static final` lists: `textToImageModels`, `freeModels`, `imageCapableModels`.

<sup>Written for commit 7741e94e99a440a374404ef4082a9ce0f3aaaccd. Summary will update on new commits. <a href="https://cubic.dev/pr/monet88/artio/pull/151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

