### PR TITLE
⚡ Bolt: Optimize AiModels list operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-18 - Optimize CachedNetworkImage Cache Key
 **Learning:** When using signed URLs that include an expiring token as a query parameter (e.g., Supabase storage URLs), `CachedNetworkImage` defaults to using the full URL as the cache key. This causes continuous cache misses and redundant downloads when the token rotates.
 **Action:** Always explicitly set the `cacheKey` property to the URL stripped of its query string (e.g., `url.split('?').first`) to ensure the cache survives token expiration.
+
+## 2024-05-24 - Static Map Lookups for Constant Lists
+**Learning:** In Dart, searching through static constant lists using `List.where((item) => item.id == id)` has O(N) complexity and creates a new iterable on every call. In performance-critical areas or frequently rebuilt UI components, this can lead to unnecessary processing.
+**Action:** For frequent ID-based lookups on static lists, pre-compute a static `Map<String, Config>` to enable O(1) direct access.

--- a/lib/core/constants/ai_models.dart
+++ b/lib/core/constants/ai_models.dart
@@ -212,27 +212,28 @@ class AiModels {
     ),
   ];
 
+  static final Map<String, AiModelConfig> _byId = {
+    for (final model in all) model.id: model,
+  };
+
   /// Get model by ID
-  static AiModelConfig? getById(String id) {
-    final matches = all.where((m) => m.id == id);
-    return matches.isEmpty ? null : matches.first;
-  }
+  static AiModelConfig? getById(String id) => _byId[id];
 
   /// Get default model
-  static AiModelConfig get defaultModel => getById(defaultModelId) ?? all.first;
+  static AiModelConfig get defaultModel => _byId[defaultModelId] ?? all.first;
 
   /// Filter models by type
   static List<AiModelConfig> byType(String type) =>
       all.where((m) => m.type == type).toList();
 
   /// Get text-to-image models only
-  static List<AiModelConfig> get textToImageModels => byType('text-to-image');
+  static final List<AiModelConfig> textToImageModels = byType('text-to-image');
 
   /// Get free models only
-  static List<AiModelConfig> get freeModels =>
+  static final List<AiModelConfig> freeModels =
       all.where((m) => !m.isPremium).toList();
 
   /// Get models that support image input
-  static List<AiModelConfig> get imageCapableModels =>
+  static final List<AiModelConfig> imageCapableModels =
       all.where((m) => m.supportsImageInput).toList();
 }


### PR DESCRIPTION
💡 What: 
- Replaced the O(N) `.where((m) => m.id == id)` search in `AiModels.getById` with a pre-computed O(1) static `Map` lookup.
- Refactored dynamic getters (`textToImageModels`, `freeModels`, `imageCapableModels`) that filter the static list into `static final` fields so they are only evaluated once lazily.

🎯 Why: 
The `AiModels` class is a core configuration file used across the app (in UI model selectors, template engines, validation, etc.). Previous implementations were doing O(N) array traversals and list memory allocations on every property access or ID lookup. 

📊 Impact: 
Reduces list traversal time for ID lookups from O(N) to O(1). Prevents unnecessary memory allocations from `.toList()` during frequent UI rebuilds in components like `ModelSelector` or `MasonryImageGrid`.

🔬 Measurement: 
Run the `test/core/constants/ai_models_test.dart` to verify that all filters and model resolution behave exactly as before. The performance gain is conceptual O(N)->O(1) complexity reduction on static references.

---
*PR created automatically by Jules for task [6176227764925010308](https://jules.google.com/task/6176227764925010308) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `AiModels` lookups and common filtered lists to cut list scans and memory allocations in UI-heavy paths. `getById` now uses a precomputed map for O(1) access; common filters are `static final` and evaluated once.

- **Refactors**
  - Added `_byId` map; updated `getById` and `defaultModel` to use it.
  - Converted `textToImageModels`, `freeModels`, and `imageCapableModels` to `static final` lists.
  - No behavior changes; existing tests pass.

<sup>Written for commit ccd28fcf15622ecde7093fa037bb1870b6aed50c. Summary will update on new commits. <a href="https://cubic.dev/pr/monet88/artio/pull/152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

