### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF and Path Traversal in image generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -32,3 +32,8 @@
 **Vulnerability:** The `reward-ad` Edge Function did not validate the HTTP method (`req.method`) for its main actions (`request-nonce` and `claim`), allowing non-POST requests to execute potentially state-modifying logic.
 **Learning:** Default unhandled methods in Supabase Edge Functions do not automatically reject unless explicitly checked, meaning endpoints intended for POST could be accessed via GET or other methods, increasing the risk of CSRF or unintended execution.
 **Prevention:** Always explicitly validate the expected HTTP method (e.g., `if (req.method !== "POST")`) at the start of the handler and return a `405 Method Not Allowed` response if the condition is not met.
+
+## 2024-05-19 - SSRF and Path Traversal in Image Resolution
+**Vulnerability:** The `resolveImageUrls` function in `generate-image` Edge Function accepted arbitrary `http://` and `https://` URLs, potentially allowing Server-Side Request Forgery (SSRF) against internal metadata services or private networks if an attacker provided malicious URLs. It also accepted Supabase storage paths containing `../` or `..\`, allowing potential path traversal attacks against the storage bucket.
+**Learning:** Functions that accept user-provided URLs or file paths must explicitly sanitize and validate them against known unsafe patterns, even if the primary purpose is just forwarding them to another service or API.
+**Prevention:** Always parse URLs using the native `URL` class and validate the `hostname` to reject private/local IP ranges (127.0.0.0/8, 169.254.0.0/16, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) and `localhost`. Reject any storage paths containing `../` or `..\` sequences.

--- a/supabase/functions/generate-image/index.ts
+++ b/supabase/functions/generate-image/index.ts
@@ -110,8 +110,30 @@ async function resolveImageUrls(
   return Promise.all(
     imageInputs.map(async (input) => {
       if (input.startsWith("http://") || input.startsWith("https://")) {
+        try {
+          const parsedUrl = new URL(input);
+          const host = parsedUrl.hostname;
+
+          if (
+            host === "localhost" ||
+            host.match(/^127\.\d+\.\d+\.\d+$/) ||
+            host.match(/^169\.254\.\d+\.\d+$/) ||
+            host.match(/^10\.\d+\.\d+\.\d+$/) ||
+            host.match(/^192\.168\.\d+\.\d+$/) ||
+            host.match(/^172\.(1[6-9]|2[0-9]|3[0-1])\.\d+\.\d+$/)
+          ) {
+            throw new Error(`Invalid URL hostname: ${host}`);
+          }
+        } catch (e) {
+          console.error(`[security] SSRF attempt or invalid URL: ${input}`);
+          throw new Error("Invalid image input URL");
+        }
         return input;
       } else {
+        if (input.includes("../") || input.includes("..\\")) {
+           console.error(`[security] Path traversal attempt: ${input}`);
+           throw new Error("Invalid storage path");
+        }
         // Treat as Supabase storage path — generate signed URL
         const { data, error } = await supabase.storage
           .from(STORAGE_BUCKET)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `resolveImageUrls` function in the `generate-image` Edge Function accepted arbitrary user-provided HTTP/HTTPS URLs and storage paths without validation. This allowed Server-Side Request Forgery (SSRF) against internal networks or metadata endpoints, and path traversal (`../`) against the Supabase storage bucket.
🎯 **Impact:** An attacker could exploit SSRF to scan internal networks or access sensitive metadata from the cloud provider, or exploit path traversal to interact with files outside the intended storage directory.
🔧 **Fix:** Added validation to `resolveImageUrls` using the `URL` class to reject localhost, loopback, link-local, and private IPv4 ranges. Also added a check to reject storage paths containing `../` or `..\`.
✅ **Verification:** Verified via `npx deno check` and running `flutter test`.

---
*PR created automatically by Jules for task [18250231061688890301](https://jules.google.com/task/18250231061688890301) started by @monet88*