### PR TITLE
🎨 Palette: [UX improvement] Improve destructive action visual cues

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -105,9 +105,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
             child: const Text('Delete'),
           ),
         ],
@@ -143,9 +146,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
             child: const Text('Logout'),
           ),
         ],


### PR DESCRIPTION
🎨 Palette: [UX improvement] Improve destructive action visual cues

💡 What: Updated "Delete Account" and "Logout" buttons in the settings dialogs to use `FilledButton` instead of `TextButton`, featuring a strong `AppColors.error` background.
🎯 Why: Simple text buttons with red text for destructive actions provide weak visual distinction. A solid filled button ensures users clearly recognize the severity of the action before confirming, preventing accidental misclicks.
♿ Accessibility: Improved visual cues by enhancing color contrast and providing a larger, clearer interactive area for the primary destructive action.

---
*PR created automatically by Jules for task [15241069634198530786](https://jules.google.com/task/15241069634198530786) started by @monet88*