### PR TITLE
🎨 Palette: [UX improvement] Styled destructive dialog buttons

### DIFF
--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -105,10 +105,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Delete'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.delete_outline_rounded, size: 18),
+            label: const Text('Delete'),
           ),
         ],
       ),
@@ -143,10 +147,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Logout'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.logout_rounded, size: 18),
+            label: const Text('Logout'),
           ),
         ],
       ),


### PR DESCRIPTION
💡 **What**: Replaced plain `TextButton`s with `FilledButton.icon` (using `AppColors.error` background and white text) for the destructive actions ("Delete Account" and "Logout") in the `SettingsScreen` confirmation dialogs. Also added appropriate icons (`delete_outline_rounded` and `logout_rounded`).

🎯 **Why**: Using a simple text button with red text for destructive actions provides weak visual distinction. A filled, strongly colored button clearly warns users of the action's severity before confirming, reducing accidental clicks and improving overall usability.

♿ **Accessibility**: Enhanced visual contrast and cues for critical, non-reversible actions.

*Matches the documented "UX pattern for destructive dialog actions" in `.jules/palette.md`.*

---
*PR created automatically by Jules for task [15503622426403068334](https://jules.google.com/task/15503622426403068334) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced plain destructive dialog buttons in Settings with `FilledButton.icon` (error red background, white text) and added matching icons for Delete and Logout. This aligns with our destructive action pattern, improves contrast, and reduces accidental confirms.

<sup>Written for commit eef5adc7263f1e488544c1b55b8d014da3fc169f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

