### PR TITLE
⚡ Bolt: [performance improvement] Optimize AI model lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-18 - Optimize CachedNetworkImage Cache Key
 **Learning:** When using signed URLs that include an expiring token as a query parameter (e.g., Supabase storage URLs), `CachedNetworkImage` defaults to using the full URL as the cache key. This causes continuous cache misses and redundant downloads when the token rotates.
 **Action:** Always explicitly set the `cacheKey` property to the URL stripped of its query string (e.g., `url.split('?').first`) to ensure the cache survives token expiration.
+
+## 2024-05-02 - Optimize Static List Filtering in Dart
+**Learning:** In Dart, calling `.where(...).toList()` on a static or constant list (like `AiModels.all`) inside a dynamic getter function forces an O(N) evaluation and allocates a new list in memory every single time the getter is accessed. In reactive UI frameworks like Flutter/Riverpod, this can happen many times per frame during rebuilds, leading to unnecessary CPU overhead and garbage collection pressure.
+**Action:** When creating filtered subsets of static reference data that never changes at runtime, always declare them as `static final` fields so they are computed exactly once at app startup and cached. Similarly, pre-compute a `Map` for $O(1)$ lookups instead of using `.where(...).first` (or `.firstWhere(...)`), which requires an O(N) scan.

--- a/lib/core/constants/ai_models.dart
+++ b/lib/core/constants/ai_models.dart
@@ -212,11 +212,12 @@ class AiModels {
     ),
   ];
 
+  static final Map<String, AiModelConfig> _modelsById = {
+    for (final m in all) m.id: m,
+  };
+
   /// Get model by ID
-  static AiModelConfig? getById(String id) {
-    final matches = all.where((m) => m.id == id);
-    return matches.isEmpty ? null : matches.first;
-  }
+  static AiModelConfig? getById(String id) => _modelsById[id];
 
   /// Get default model
   static AiModelConfig get defaultModel => getById(defaultModelId) ?? all.first;
@@ -226,13 +227,13 @@ class AiModels {
       all.where((m) => m.type == type).toList();
 
   /// Get text-to-image models only
-  static List<AiModelConfig> get textToImageModels => byType('text-to-image');
+  static final List<AiModelConfig> textToImageModels = byType('text-to-image');
 
   /// Get free models only
-  static List<AiModelConfig> get freeModels =>
+  static final List<AiModelConfig> freeModels =
       all.where((m) => !m.isPremium).toList();
 
   /// Get models that support image input
-  static List<AiModelConfig> get imageCapableModels =>
+  static final List<AiModelConfig> imageCapableModels =
       all.where((m) => m.supportsImageInput).toList();
 }


### PR DESCRIPTION
💡 **What:** Optimized static list filtering and lookups in `AiModels`.
🎯 **Why:** The getters for `textToImageModels`, `freeModels`, and `imageCapableModels` were executing an O(N) filter and allocating a new list in memory on every access, which could cause garbage collection pressure during UI rebuilds. `getById` was also performing an O(N) list scan.
📊 **Impact:** Reduces O(N) list evaluations to O(1) property accesses, saving CPU cycles and memory allocations.
🔬 **Measurement:** Analyzed the file with Dart tools and ran full tests successfully.

---
*PR created automatically by Jules for task [12039252436782550110](https://jules.google.com/task/12039252436782550110) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `AiModels` filtering and lookups to remove repeated O(N) scans. Precomputed maps and static lists for O(1) access, cutting CPU and allocations during UI rebuilds.

- **Refactors**
  - Added `_modelsById` map and updated `getById` to use it (O(1)).
  - Converted `textToImageModels`, `freeModels`, and `imageCapableModels` from getters to `static final` lists computed once.
  - Kept `byType` for ad-hoc filtering when needed.

<sup>Written for commit f403f2d41ef43ed2cfe28d8442dea9465953f48e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

