### PR TITLE
🎨 Palette: Improve UX of destructive dialog actions in Settings

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,6 @@
 ## 2025-03-04 - UX pattern for destructive dialog actions
 **Learning:** Using a simple `TextButton` with red text for destructive actions (like "Delete") in dialogs provides weak visual distinction and poor accessibility cues for critical actions.
 **Action:** Use a `FilledButton` (or `FilledButton.icon` to be even clearer) with a strong color background (e.g., `Colors.red`) and contrasting text (`Colors.white`) for destructive actions to ensure users clearly recognize the severity of the action before confirming.
+## 2025-03-04 - UX pattern for destructive dialog actions
+**Learning:** Using a simple `TextButton` with red text for destructive actions (like "Logout" or "Delete") in dialogs provides weak visual distinction and poor accessibility cues for critical actions.
+**Action:** Use a `FilledButton` (or `FilledButton.icon` to be even clearer) with a strong color background (e.g., `AppColors.error` or `Colors.red`) and contrasting text (`Colors.white`) for destructive actions to ensure users clearly recognize the severity of the action before confirming.

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -105,10 +105,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Delete'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.delete_outline_rounded, size: 18),
+            label: const Text('Delete'),
           ),
         ],
       ),
@@ -143,10 +147,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             onPressed: () => Navigator.pop(context, false),
             child: const Text('Cancel'),
           ),
-          TextButton(
+          FilledButton.icon(
             onPressed: () => Navigator.pop(context, true),
-            style: TextButton.styleFrom(foregroundColor: AppColors.error),
-            child: const Text('Logout'),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.error,
+              foregroundColor: Colors.white,
+            ),
+            icon: const Icon(Icons.logout_rounded, size: 18),
+            label: const Text('Logout'),
           ),
         ],
       ),


### PR DESCRIPTION
💡 What: The UX enhancement added:
Replaced simple `TextButton` widgets with `FilledButton.icon` for destructive actions ("Logout" and "Delete") in the `SettingsScreen` confirmation dialogs. Used `AppColors.error` background with white foreground text and appropriate icons (`logout_rounded` and `delete_outline_rounded`).

🎯 Why: The user problem it solves:
Critical destructive actions (like logging out or permanently deleting an account) shouldn't blend in with standard primary/secondary buttons. Giving them a prominent red background and icon makes the severity of the action immediately obvious, preventing accidental confirmations and improving cognitive recognition.

♿ Accessibility:
Provides better visual contrast and stronger semantic cues for critical actions. Screen readers and low-vision users will benefit from the clearer visual hierarchy.

---
*PR created automatically by Jules for task [12437594033609951063](https://jules.google.com/task/12437594033609951063) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlight destructive actions in Settings dialogs by replacing `TextButton`s with `FilledButton.icon` for "Delete" and "Logout" using `AppColors.error` backgrounds, white text, and `delete_outline_rounded`/`logout_rounded` icons. This makes the risk obvious, improves accessibility, and helps prevent accidental taps.

<sup>Written for commit 44a5580c2779c61824be6221e818fd3ac1712704. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

