### PR TITLE
⚡ Bolt: [performance improvement] Optimize AiModels Lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -41,3 +41,7 @@
 ## 2025-05-18 - Optimize CachedNetworkImage Cache Key
 **Learning:** When using signed URLs that include an expiring token as a query parameter (e.g., Supabase storage URLs), `CachedNetworkImage` defaults to using the full URL as the cache key. This causes continuous cache misses and redundant downloads when the token rotates.
 **Action:** Always explicitly set the `cacheKey` property to the URL stripped of its query string (e.g., `url.split('?').first`) to ensure the cache survives token expiration.
+
+## $(date +%Y-%m-%d) - Dynamic Initialization for Static Grouping
+**Learning:** Hardcoding string keys when grouping a static list into a Map (e.g., `_modelsByType`) creates a maintainability trap where adding a new type silently breaks without a compiler warning.
+**Action:** When pre-computing an O(1) grouped lookup table from a static list, always dynamically build the map (e.g., using `.fold()` or collection `for` in Dart) over the list elements to ensure automatic synchronization and support for new values.

--- a/lib/core/constants/ai_models.dart
+++ b/lib/core/constants/ai_models.dart
@@ -212,27 +212,34 @@ class AiModels {
     ),
   ];
 
+  static final Map<String, AiModelConfig> _modelsById = {
+    for (final model in all) model.id: model,
+  };
+
+  static final Map<String, List<AiModelConfig>> _modelsByType =
+      all.fold<Map<String, List<AiModelConfig>>>(
+    {},
+    (map, model) {
+      map.putIfAbsent(model.type, () => []).add(model);
+      return map;
+    },
+  );
+
+  static final List<AiModelConfig> textToImageModels =
+      _modelsByType['text-to-image'] ?? [];
+
+  static final List<AiModelConfig> freeModels =
+      all.where((m) => !m.isPremium).toList();
+
+  static final List<AiModelConfig> imageCapableModels =
+      all.where((m) => m.supportsImageInput).toList();
+
   /// Get model by ID
-  static AiModelConfig? getById(String id) {
-    final matches = all.where((m) => m.id == id);
-    return matches.isEmpty ? null : matches.first;
-  }
+  static AiModelConfig? getById(String id) => _modelsById[id];
 
   /// Get default model
   static AiModelConfig get defaultModel => getById(defaultModelId) ?? all.first;
 
   /// Filter models by type
-  static List<AiModelConfig> byType(String type) =>
-      all.where((m) => m.type == type).toList();
-
-  /// Get text-to-image models only
-  static List<AiModelConfig> get textToImageModels => byType('text-to-image');
-
-  /// Get free models only
-  static List<AiModelConfig> get freeModels =>
-      all.where((m) => !m.isPremium).toList();
-
-  /// Get models that support image input
-  static List<AiModelConfig> get imageCapableModels =>
-      all.where((m) => m.supportsImageInput).toList();
+  static List<AiModelConfig> byType(String type) => _modelsByType[type] ?? [];
 }


### PR DESCRIPTION
💡 What: Replace O(N) dynamic list filtering (`.where`) in `AiModels` with pre-computed O(1) maps (`_modelsById`, `_modelsByType`) and static final lists.

🎯 Why: In Flutter apps, dynamic getters executing `.where(...).toList()` on static sets create redundant list memory allocations on every read, increasing garbage collection (GC) pressure and unnecessarily spending CPU cycles. `getById` executing `.isEmpty` followed by `.first` evaluates the iterable twice per lookup.

📊 Impact: Reduces iteration overhead and memory allocation for models lookup to zero per access. It is completely safe and backwards compatible since the list of models is static.

🔬 Measurement: Verify tests still pass using `flutter test test/core/constants/ai_models_test.dart`.

---
*PR created automatically by Jules for task [14755100019143264222](https://jules.google.com/task/14755100019143264222) started by @monet88*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up `AiModels` lookups by replacing per-read `.where()` scans with precomputed maps and static lists. `getById` and `byType` are now O(1) and avoid repeated allocations.

- **Refactors**
  - Added `_modelsById` and `_modelsByType` built from `all` for constant-time lookups.
  - Converted common subsets to `static final` lists: `textToImageModels`, `freeModels`, `imageCapableModels`.
  - Kept behavior the same; `defaultModel` logic unchanged and `byType` returns `[]` when no match.

<sup>Written for commit 4362c3b58c4e5246c5eeb4d53d3771c66f9ad8fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

